### PR TITLE
Static fly build

### DIFF
--- a/tasks/scripts/fly-build
+++ b/tasks/scripts/fly-build
@@ -19,11 +19,8 @@ fi
 
 pushd concourse
   export CGO_ENABLED=1
-  if [ "$platform" = "linux" ]; then
-    export CGO_ENABLED=0
-  fi
 
-  go build -ldflags "$ldflags" -o $output/fly ./fly
+  go build --ldflags '-linkmode external -extldflags "-static"' -o $output/fly ./fly
 
   if [ "$platform" = "linux" ] && which ldd && ldd $output/fly; then
     echo "binary is not static; aborting"

--- a/tasks/scripts/fly-build
+++ b/tasks/scripts/fly-build
@@ -20,7 +20,11 @@ fi
 pushd concourse
   export CGO_ENABLED=1
 
-  go build --ldflags '-linkmode external -extldflags "-static"' -o $output/fly ./fly
+  if [ "$platform" = "linux" ]; then
+    go build --ldflags "$ldflags" '-linkmode external -extldflags "-static"' -o $output/fly ./fly
+  else
+    go build -ldflags "$ldflags" -o $output/fly ./fly
+  fi
 
   if [ "$platform" = "linux" ] && which ldd && ldd $output/fly; then
     echo "binary is not static; aborting"

--- a/tasks/scripts/fly-build
+++ b/tasks/scripts/fly-build
@@ -21,10 +21,10 @@ pushd concourse
   export CGO_ENABLED=1
 
   if [ "$platform" = "linux" ]; then
-    go build --ldflags "$ldflags" '-linkmode external -extldflags "-static"' -o $output/fly ./fly
-  else
-    go build -ldflags "$ldflags" -o $output/fly ./fly
+    ldflags+='-linkmode external -extldflags "-static"'
   fi
+
+  go build --ldflags "$ldflags" -o $output/fly ./fly
 
   if [ "$platform" = "linux" ] && which ldd && ldd $output/fly; then
     echo "binary is not static; aborting"

--- a/tasks/scripts/fly-build
+++ b/tasks/scripts/fly-build
@@ -24,7 +24,7 @@ pushd concourse
     ldflags+='-linkmode external -extldflags "-static"'
   fi
 
-  go build --ldflags "$ldflags" -o $output/fly ./fly
+  go build -ldflags "$ldflags" -o $output/fly ./fly
 
   if [ "$platform" = "linux" ] && which ldd && ldd $output/fly; then
     echo "binary is not static; aborting"


### PR DESCRIPTION
Zstd library needs to be used for fly execute. Zstd uses go bindings for the underlying C library. We need to turn CGO back on and pass it extra flags so it links everything statically.