### PR TITLE
move norsk mirror pipeline over to ci repo

### DIFF
--- a/pipelines/norsk-mirror.yml
+++ b/pipelines/norsk-mirror.yml
@@ -1,0 +1,40 @@
+---
+resources:
+- name: latest-scan-status
+  type: git
+  source:
+    private_key: ((norsk_deploy_key))
+    uri: git@github.com:pivotal/oslo-scan-status.git
+    paths: [ p-concourse/* ]
+- name: 4.2.X-scan-status
+  type: git
+  source:
+    private_key: ((norsk_deploy_key))
+    uri: git@github.com:pivotal/oslo-scan-status.git
+    paths: [ p-concourse-4.2.x/* ]
+- name: ci
+  type: git
+  icon: &git-icon github-circle
+  source:
+    uri: https://github.com/concourse/ci.git
+    branch: master
+
+jobs:
+- name: check-p-concourse-latest
+  plan:
+  - get: latest-scan-status
+    trigger: true
+  - get: ci
+  - task: check-status-file
+    file: ci/tasks/check-norsk-status.yml
+    input_mapping: {scan-status: latest-scan-status}
+
+- name: check-p-concourse-4.2.X
+  plan:
+  - get: 4.2.X-scan-status
+    trigger: true
+  - get: ci
+  - task: check-status-file
+    file: ci/tasks/check-norsk-status.yml
+    input_mapping: {scan-status: 4.2.X-scan-status}
+

--- a/tasks/check-norsk-status.yml
+++ b/tasks/check-norsk-status.yml
@@ -1,0 +1,11 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source: { repository: ubuntu }
+
+inputs:
+- name: scan-status
+
+run:
+  path: ci/tasks/scripts/check-norsk-status

--- a/tasks/scripts/check-norsk-status
+++ b/tasks/scripts/check-norsk-status
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+status_file=scan-status/p-concourse/status.json
+cat "$status_file"
+
+num_failures="$(grep -c '"status": "failed"' $status_file)"
+echo ""
+
+if [ "$num_failures" -eq 0 ]; then
+  echo "No failures found"
+  exit 0
+else
+  echo "$num_failures failures found! Please check your norsk-viewers pipelines specified in the status.json and resolve the errors. Contact the OSL team if you need help."
+  exit 1
+fi


### PR DESCRIPTION
Copied over norsk-pipeline from github.com/concourse/concourse/pull/3598 to this repo and did some cleanup.

Signed-off-by: Taylor Silva <tsilva@pivotal.io>
Co-authored-by: Divya Dadlani <ddadlani@pivotal.io>