### PR TITLE
Add pipeline for testing PR's from helm chart

### DIFF
--- a/pipelines/helm-prs.yml
+++ b/pipelines/helm-prs.yml
@@ -1,0 +1,75 @@
+---
+resource_types:
+- name: pull-request
+  type: registry-image
+  source: {repository: teliaoss/github-pr-resource}
+
+resources:
+- name: stable-concourse-pr
+  type: pull-request
+  icon: source-pull
+  source:
+    repository: helm/charts
+    paths:
+      - stable/concourse/
+    access_token: ((pr_access_token))
+
+- name: concourse
+  type: git
+  icon: github-circle
+  source:
+    uri: https://github.com/concourse/concourse.git
+    branch: master
+
+- name: ci
+  type: git
+  icon: github-circle
+  source:
+    uri: https://github.com/concourse/ci.git
+    branch: master
+
+- name: concourse-rc-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: concourse/concourse-rc
+    username: ((docker.username))
+    password: ((docker.password))
+
+- name: unit-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: concourse/unit
+    username: ((docker.username))
+    password: ((docker.password))
+
+jobs:
+- name: k8s-topgun
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: stable-concourse-pr
+    - get: concourse
+    - get: concourse-rc-image
+    - get: ci
+    - get: unit-image
+  - task: k8s-topgun
+    file: ci/tasks/k8s-topgun.yml
+    input_mapping:
+      charts: stable-concourse-pr
+    image: unit-image
+    params:
+      KUBE_CONFIG: ((kube_config))
+      CONCOURSE_IMAGE_NAME: concourse/concourse-rc
+    on_success:
+      put: stable-concourse-pr
+      params:
+        path: stable-concourse-pr
+        comment: "Topgun tests passed: $ATC_EXTERNAL_URL/builds/$BUILD_ID"
+    on_failure:
+      put: stable-concourse-pr
+      params:
+        path: stable-concourse-pr
+        comment: "Topgun tests failed: $ATC_EXTERNAL_URL/builds/$BUILD_ID"


### PR DESCRIPTION
This pipeline watches the https://github.com/helm/charts repo for any PR's that hit our directory (`stable/concourse`).

The `k8s-topgun` job is currently not set to `trigger: true` for when a new PR is submitted. When we want to test a PR against topgun we can pin the PR (if needed) and then trigger the job. On success or failure the pipeline will post a comment to the PR with a link to the build that ran against the PR.

Pipeline is exposed and the job logs are public, which matches the current state of the `concourse/k8s/topgun` job.