### PR TITLE
update fly-build.ps1 with PATH to gcc

### DIFF
--- a/tasks/scripts/fly-build.ps1
+++ b/tasks/scripts/fly-build.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = "Stop"
 trap { $host.SetShouldExit(1) }
 
-$env:Path += ";C:\Go\bin;C:\Program Files\Git\cmd"
+$env:Path += ";C:\Go\bin;C:\Program Files\Git\cmd;C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
 
 $env:GOPATH = "$pwd\gopath"
 $env:Path += ";$pwd\gopath\bin"


### PR DESCRIPTION
Previously we didn't need to do so as `fly` used to not require building any native code (CGO).

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>