### PR TITLE
Remove path-checking in images' resource configs

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -73,8 +73,6 @@ jobs:
   plan:
   - in_parallel:
     - get: ci
-      resource: unit-dockerfile
-      trigger: true
     - get: builder
   - task: build
     image: builder
@@ -117,7 +115,6 @@ jobs:
   plan:
   - in_parallel:
     - get: ci
-      resource: golang-builder-dockerfile
       trigger: true
     - get: builder
     - get: golang-linux
@@ -1206,22 +1203,6 @@ resources:
     username: ((basic_auth.username))
     password: ((basic_auth.password))
     concourse_url: https://ci.concourse-ci.org
-
-- name: unit-dockerfile
-  type: git
-  icon: *git-icon
-  source:
-    uri: https://github.com/concourse/ci.git
-    branch: master
-    paths: [dockerfiles/unit]
-
-- name: golang-builder-dockerfile
-  type: git
-  icon: *git-icon
-  source:
-    uri: https://github.com/concourse/ci.git
-    branch: master
-    paths: [dockerfiles/golang-builder]
 
 - name: dev-image
   type: registry-image


### PR DESCRIPTION
Having a resource that restricts the path that gives us versions for
`golang-builder-dockerfile`, we end up without the necessary files to
properly running the task.

Adding the task configuration to the list of path helps, but then we
miss the configuration for the notification step, meaning that we'd then
need to have another `get` just for that.

As there seems not to be problematic to constantly build
`concourse/golang-builder` on every push to `ci` anyway, we removed the
path-specific resources in order to ensure that we don't end up using
old configurations.

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>
Co-authored-by: Joshua Winters <jwinters@pivotal.io>