### PR TITLE
ci/k8s-smoke: Replace until with while true to fix k8s-smoke

### DIFF
--- a/tasks/scripts/wait-worker
+++ b/tasks/scripts/wait-worker
@@ -46,17 +46,21 @@ try_until_responding() {
 
   echo "waiting for a worker to be running"
 
-  until fly -t $TARGET_NAME workers | grep 'running' &> /dev/null; do
-    echo -n
+  while true; do
+    workers= fly -t $TARGET_NAME workers | grep 'running'
+    if [ -z workers ]; then
+      echo -n '.'
 
-    ((ticks++))
+      ((ticks++))
+      if [[ $ticks -ge $MAX_TICKS ]]; then
+        echo "giving up. :("
+        exit 1
+      fi
 
-    if [[ $ticks -ge $MAX_TICKS ]]; then
-      echo "giving up. :("
-      exit 1
+      sleep 1
+    else
+     exit
     fi
-
-    sleep 1
   done
 }
 


### PR DESCRIPTION
- When using `until` it only runs when the exit code of the check command is other than zero.
- In the previous case, this wasn't happening because `fly workers` exits with `0`, making it impossible to enter the loop.
- We replaced that with a `while true` then exiting when we find a worker.

fixes: #44 