### PR TITLE
Add quickstart tests to main pipeline

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -29,6 +29,10 @@ groups:
   - upgrade
   - downgrade
 
+- name: quickstart
+  jobs:
+  - quickstart-smoke
+
 - name: k8s
   jobs:
   - k8s-check-helm-params
@@ -589,6 +593,32 @@ jobs:
     image: unit-image
     file: ci/tasks/smoke.yml
     input_mapping: {endpoint-info: outputs}
+  on_success: *fixed-concourse
+  on_failure: *broke-concourse
+
+- name: quickstart-smoke
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [build-rc-image]
+      trigger: true
+    - get: concourse-rc-image
+      passed: [build-rc-image]
+      params: {format: oci}
+      trigger: true
+    - get: version
+      passed: [build-rc-image]
+      trigger: true
+    - get: unit-image
+      passed: [build-rc-image]
+    - get: ci
+  - task: quickstart-smoke
+    image: unit-image
+    file: ci/tasks/quickstart-smoke.yml
+    params:
+      RELEASE_NAME: concourse-smoke
   on_success: *fixed-concourse
   on_failure: *broke-concourse
 

--- a/tasks/quickstart-smoke.yml
+++ b/tasks/quickstart-smoke.yml
@@ -1,0 +1,22 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/unit}
+
+params:
+  RELEASE_NAME:
+
+inputs:
+- name: concourse
+- name: ci
+- name: docs
+- name: concourse-rc-image
+
+caches:
+- path: gopath
+- path: concourse/web/wats/node_modules
+
+run:
+  path: ci/tasks/scripts/quickstart-smoke

--- a/tasks/scripts/quickstart-smoke
+++ b/tasks/scripts/quickstart-smoke
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ex -u
+
+source ci/tasks/scripts/docker-helpers.sh
+
+start_docker
+
+[ -d concourse-rc-image ] && docker load -i concourse-rc-image/image.tar
+# concourse/concourse-rc:latest
+
+pushd docs
+  docker-compose -f docker-compose.yml -f latest-rc.override.yml up -d
+popd
+
+# now run the watjs/smoke tests
+mkdir -p endpoint-info
+pushd endpoint-info
+  echo "localhost" > instance_ip
+  echo "test" > admin_username
+  echo "test" > admin_password
+popd
+
+ci/tasks/scripts/smoke
+
+pushd docs
+  docker-compose down
+popd
+
+stop_docker


### PR DESCRIPTION
Created a new job that runs web/wats/smoke against the latest concourse-rc image with a docker file that uses the `quickstart` command.

This is currently blocked by https://github.com/concourse/docs/pull/228


