### PR TITLE
Add a step to bosh-prod-deploy to update PKS external worker

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -898,6 +898,25 @@ jobs:
         volume_sweeper_max_in_flight: 3
         vault_shared_path: "shared"
         vault_host: vault.concourse-ci.org
+  - put: prod-pks-worker-deployment
+    tags: [pks]
+    params:
+      manifest: cbd/cluster/external-worker.yml
+      stemcells:
+      - gcp-xenial-stemcell/*.tgz
+      releases:
+      - concourse-release/*.tgz
+      ops_files:
+      - prod/pks-worker/ops.yml
+      vars_files:
+      - cbd/versions.yml
+      vars:
+        azs: [default]
+        deployment_name: prod-external-worker
+        external_worker_network_name: default
+        instances: 1
+        tsa_host: ci.concourse-ci.org
+        worker_vm_type: medium.disk
 
 - name: shipit
   public: true
@@ -1531,6 +1550,16 @@ resources:
     client: ((bosh_client.id))
     client_secret: ((bosh_client.secret))
     deployment: concourse-prod
+
+- name: prod-pks-worker-deployment
+  type: bosh-deployment
+  icon: sync
+  source:
+    target: ((bosh_pks_target))
+    ca_cert: ((bosh_pks_ca_cert))
+    client: ((bosh_pks_client.id))
+    client_secret: ((bosh_pks_client.secret))
+    deployment: prod-external-worker
 
 - name: wings-deployment
   type: bosh-deployment

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -819,6 +819,8 @@ jobs:
     - get: cbd
       trigger: true
     - get: gcp-windows-stemcell
+    - get: vsphere-xenial-stemcell
+      tags: [pks]
     - get: bbr-sdk-release
     - get: prod
     - get: ci
@@ -899,11 +901,12 @@ jobs:
         vault_shared_path: "shared"
         vault_host: vault.concourse-ci.org
   - put: prod-pks-worker-deployment
+    inputs: [cbd, concourse-release, vsphere-xenial-stemcell, prod]
     tags: [pks]
     params:
       manifest: cbd/cluster/external-worker.yml
       stemcells:
-      - gcp-xenial-stemcell/*.tgz
+      - vsphere-xenial-stemcell/*.tgz
       releases:
       - concourse-release/*.tgz
       ops_files:
@@ -1555,11 +1558,11 @@ resources:
   type: bosh-deployment
   icon: sync
   source:
-    target: ((bosh_pks_target))
     ca_cert: ((bosh_pks_ca_cert))
     client: ((bosh_pks_client.id))
     client_secret: ((bosh_pks_client.secret))
     deployment: prod-external-worker
+    target: ((bosh_pks_target))
 
 - name: wings-deployment
   type: bosh-deployment
@@ -1575,6 +1578,12 @@ resources:
   icon: *release-icon
   source:
     name: bosh-google-kvm-ubuntu-xenial-go_agent
+
+- name: vsphere-xenial-stemcell
+  type: bosh-io-stemcell
+  icon: *release-icon
+  source:
+    name: bosh-vsphere-esxi-ubuntu-xenial-go_agent
 
 - name: gcp-windows-stemcell
   type: bosh-io-stemcell


### PR DESCRIPTION
We're adding a step to the bosh-prod-deploy that updates the external worker that is managed by a vsphere bosh director. This external worker is needed for us to run topgun/k8s on the PKS cluster that we have on vsphere. The worker is already there so nothing manually needs to be done unless the worker breaks.

See concourse/ci#40 for more details.

CC @cirocosta 

---

TODO:

- [x] add `pks` variables to vault 
