### PR TITLE
Renamed bbr-sdk resource and missed one spot

### DIFF
--- a/tasks/scripts/topgun
+++ b/tasks/scripts/topgun
@@ -14,7 +14,7 @@ export BPM_RELEASE_VERSION="$(cat bpm-release/version)"
 export POSTGRES_RELEASE_VERSION="$(cat postgres-release/version)"
 export VAULT_RELEASE_VERSION="$(cat vault-release/version)"
 export CREDHUB_RELEASE_VERSION="$(cat credhub-release/version)"
-export BACKUP_AND_RESTORE_SDK_RELEASE_VERSION="$(cat backup-and-restore-sdk-release/version)"
+export BACKUP_AND_RESTORE_SDK_RELEASE_VERSION="$(cat bbr-sdk-release/version)"
 export STEMCELL_VERSION="$(cat stemcell/version)"
 
 bosh upload-release concourse-release/*.tgz


### PR DESCRIPTION
In #60 I had removed a duplicate bbr-sdk resource and had updated the name everywhere... except for this one spot! It broke topgun: https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/bosh-topgun/builds/514

Did an `ag backup-and-restore-sdk-release` to ensure I didn't miss anything else this time.
