### PR TITLE
wait for cloud-init before apt-get update

### DIFF
--- a/deployments/smoke/smoke.tf
+++ b/deployments/smoke/smoke.tf
@@ -75,6 +75,7 @@ resource "google_compute_instance" "smoke" {
   provisioner "remote-exec" {
     inline = [
       "set -e -x",
+      "until [ -f /var/lib/cloud/instance/boot-finished ]; do sleep 1; done",
       "apt-get update",
       "apt-get -y install postgresql-10",
       "sudo -i -u postgres createuser concourse",


### PR DESCRIPTION
cloud-init will set up the correct apt sources, so we can avoid broken packages.