### PR TITLE
Make yaml yml

### DIFF
--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -56,7 +56,7 @@ jobs:
       run:
         dir: charts-maintenance
         path: make
-        args: [pipeline.yaml]
+        args: [pipeline.yml]
   - put: prod
     params:
       pipelines:
@@ -92,7 +92,7 @@ jobs:
         config_file: pipelines/pipelines/concourse.yml
       - name: concourse-charts
         team: main
-        config_file: charts-maintenance/pipeline.yaml
+        config_file: charts-maintenance/pipeline.yml
       - name: new-algorithm
         team: main
         config_file: pipelines/pipelines/branch.yml


### PR DESCRIPTION
After the addition of `make` and change to the extension used in that pipeline filename (see https://github.com/concourse/charts/commit/781e0b8f305d54db13cce3eb12e2aa764de115e0), we can reference the right name 👍 

Fixes #54