### PR TITLE
Have Wings in its own pipeline

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -46,7 +46,6 @@ groups:
   - bosh-smoke
   - bosh-topgun
   - bosh-prod-deploy
-  - bosh-wings-deploy
   - bosh-check-props
   - merge-cbd
 
@@ -1048,58 +1047,6 @@ jobs:
   - put: version
     params: {file: final-version/version}
 
-- name: bosh-wings-deploy
-  serial: true
-  plan:
-  - in_parallel:
-    - get: concourse
-      passed: [shipit]
-    - get: version
-      passed: [shipit]
-    - get: concourse-release
-      passed: [shipit]
-    - get: bpm-release
-      passed: [shipit]
-    - get: gcp-xenial-stemcell
-      passed: [bosh-prod-deploy]
-    - get: cbd
-      passed: [bosh-prod-deploy]
-    - get: prod
-    - get: ci
-  - put: wings-deployment
-    params:
-      manifest: cbd/cluster/concourse.yml
-      stemcells:
-      - gcp-xenial-stemcell/*.tgz
-      releases:
-      - concourse-release/*.tgz
-      - bpm-release/*.tgz
-      ops_files:
-      - cbd/cluster/operations/dev-versions.yml
-      - cbd/cluster/operations/privileged-http.yml
-      - cbd/cluster/operations/privileged-https.yml
-      - cbd/cluster/operations/tls.yml
-      - cbd/cluster/operations/web-network-extension.yml
-      - cbd/cluster/operations/scale.yml
-      - cbd/cluster/operations/syslog_forwarder.yml
-      - cbd/cluster/operations/team-authorized-keys.yml
-      - cbd/cluster/operations/storage-driver.yml
-      - cbd/cluster/operations/external-postgres.yml
-      - cbd/cluster/operations/external-postgres-tls.yml
-      - cbd/cluster/operations/influxdb.yml
-      - cbd/cluster/operations/container-placement-strategy.yml
-      - cbd/cluster/operations/github-auth.yml
-      - cbd/cluster/operations/add-local-users.yml
-      - cbd/cluster/operations/worker-rebalancing.yml
-      - cbd/cluster/operations/encryption.yml
-      - cbd/cluster/operations/garden-dns.yml
-      - cbd/cluster/operations/max-in-flight.yml
-      - cbd/cluster/operations/worker-max-in-flight.yml
-      - cbd/cluster/operations/enable-global-resources.yml
-      - prod/wings/ops.yml
-      vars_files:
-      - prod/wings/vars.yml
-
 - name: publish-binaries
   serial: true
   plan:
@@ -1640,15 +1587,6 @@ resources:
     client_secret: ((bosh_pks_client.secret))
     deployment: prod-external-worker
     target: ((bosh_pks_target))
-
-- name: wings-deployment
-  type: bosh-deployment
-  icon: airplane-takeoff
-  source:
-    target: ((bosh_target))
-    client: ((bosh_client.id))
-    client_secret: ((bosh_client.secret))
-    deployment: concourse-wings
 
 - name: gcp-xenial-stemcell
   type: bosh-io-stemcell

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -66,6 +66,9 @@ jobs:
       - name: prs
         team: main
         config_file: pipelines/pipelines/prs.yml
+      - name: wings
+        team: main
+        config_file: pipelines/pipelines/wings.yml
       - name: release-5.2.x
         team: main
         config_file: pipelines/pipelines/release.yml

--- a/pipelines/wings.yml
+++ b/pipelines/wings.yml
@@ -1,0 +1,102 @@
+jobs:
+- name: bosh-wings-deploy
+  serial: true
+  plan:
+  - in_parallel:
+    - get: bpm-release
+    - get: cbd
+    - get: concourse-release
+    - get: gcp-xenial-stemcell
+    - get: prod
+  - put: wings-deployment
+    params:
+      manifest: cbd/cluster/concourse.yml
+      stemcells:
+      - gcp-xenial-stemcell/*.tgz
+      releases:
+      - concourse-release/*.tgz
+      - bpm-release/*.tgz
+      ops_files:
+      - cbd/cluster/operations/dev-versions.yml
+      - cbd/cluster/operations/privileged-http.yml
+      - cbd/cluster/operations/privileged-https.yml
+      - cbd/cluster/operations/tls.yml
+      - cbd/cluster/operations/web-network-extension.yml
+      - cbd/cluster/operations/scale.yml
+      - cbd/cluster/operations/syslog_forwarder.yml
+      - cbd/cluster/operations/team-authorized-keys.yml
+      - cbd/cluster/operations/storage-driver.yml
+      - cbd/cluster/operations/external-postgres.yml
+      - cbd/cluster/operations/external-postgres-tls.yml
+      - cbd/cluster/operations/influxdb.yml
+      - cbd/cluster/operations/container-placement-strategy.yml
+      - cbd/cluster/operations/github-auth.yml
+      - cbd/cluster/operations/add-local-users.yml
+      - cbd/cluster/operations/worker-rebalancing.yml
+      - cbd/cluster/operations/encryption.yml
+      - cbd/cluster/operations/garden-dns.yml
+      - cbd/cluster/operations/max-in-flight.yml
+      - cbd/cluster/operations/worker-max-in-flight.yml
+      - cbd/cluster/operations/enable-global-resources.yml
+      - prod/wings/ops.yml
+      vars_files:
+      - prod/wings/vars.yml
+
+
+
+resource_types:
+- name: bosh-deployment
+  type: registry-image
+  source: {repository: cloudfoundry/bosh-deployment-resource}
+
+- name: bosh-release
+  type: registry-image
+  source: {repository: dpb587/bosh-release-resource}
+
+
+
+resources:
+- name: wings-deployment
+  type: bosh-deployment
+  icon: airplane-takeoff
+  source:
+    target: ((bosh_target))
+    client: ((bosh_client.id))
+    client_secret: ((bosh_client.secret))
+    deployment: concourse-wings
+
+- name: bpm-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry/bpm-release
+
+- name: cbd
+  type: git
+  source:
+    uri: git@github.com:concourse/concourse-bosh-deployment.git
+    branch: develop
+    private_key: ((concourse_deployment_repo_private_key))
+
+- name: concourse-release
+  type: bosh-release
+  source:
+    uri: https://github.com/concourse/concourse-bosh-release
+    branch: master
+    dev_releases: true
+    private_config:
+      blobstore:
+        provider: gcs
+        options:
+          credentials_source: static
+          json_key: ((concourse_artifacts_json_key))
+
+- name: gcp-xenial-stemcell
+  type: bosh-io-stemcell
+  source:
+    name: bosh-google-kvm-ubuntu-xenial-go_agent
+
+- name: prod
+  type: git
+  source:
+    uri: https://github.com/concourse/prod.git
+    branch: master


### PR DESCRIPTION
Hey,

Here we're separating the deployment of Wings into its own pipeline so that we can:

- easily pin versions without affecting the whole development pipeline
- leverage any release candidates regardless of which pipeline generated them

Thank you!  