### PR TITLE
concourse: remove passed constraints for `unit-image`

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -291,8 +291,6 @@ jobs:
       passed: [unit, dev-image]
       trigger: true
     - get: unit-image
-      passed: [unit, dev-image]
-      trigger: true
     - get: dev-image
       passed: [dev-image]
       trigger: true
@@ -317,8 +315,6 @@ jobs:
       passed: [unit, dev-image]
       trigger: true
     - get: unit-image
-      passed: [unit, dev-image]
-      trigger: true
     - get: dev-image
       passed: [dev-image]
       trigger: true
@@ -347,7 +343,6 @@ jobs:
       params: {format: oci}
       trigger: true
     - get: unit-image
-      passed: [unit, dev-image]
     - get: concourse-image-alpine
       params: {format: oci}
     - get: postgres-image
@@ -374,7 +369,6 @@ jobs:
       params: {format: oci}
       trigger: true
     - get: unit-image
-      passed: [unit, dev-image]
     - get: concourse-image-alpine
       params: {format: oci}
     - get: postgres-image
@@ -410,7 +404,6 @@ jobs:
     - get: charts
       trigger: true
     - get: unit-image
-      passed: [build-rc-image]
     - get: ci
   - try:
       task: try-delete
@@ -465,8 +458,6 @@ jobs:
       trigger: true
       params: {format: oci}
     - get: unit-image
-      passed: [k8s-smoke]
-      trigger: true
     - get: charts
       trigger: true
       passed: [k8s-smoke]
@@ -500,8 +491,6 @@ jobs:
       tags: [pks]
       params: {format: oci}
     - get: unit-image
-      passed: [k8s-smoke]
-      trigger: true
       tags: [pks]
     - get: charts
       trigger: true
@@ -538,8 +527,6 @@ jobs:
       passed: [build-rc-image]
       trigger: true
     - get: unit-image
-      passed: [build-rc-image]
-      trigger: true
     - get: charts
       trigger: true
     - get: ci
@@ -561,8 +548,6 @@ jobs:
       trigger: true
       passed: [testflight, watsjs, upgrade, downgrade]
     - get: unit-image
-      passed: [testflight, watsjs, upgrade, downgrade]
-      trigger: true
     - get: ci
   - put: version
     params: {pre: rc}
@@ -576,8 +561,6 @@ jobs:
       passed: [rc]
       trigger: true
     - get: unit-image
-      passed: [rc]
-      trigger: true
     - get: version
       passed: [rc]
       trigger: true
@@ -655,8 +638,6 @@ jobs:
       passed: [build-rc]
       trigger: true
     - get: unit-image
-      passed: [build-rc]
-      trigger: true
     - get: version
       passed: [build-rc]
       trigger: true
@@ -714,8 +695,6 @@ jobs:
       passed: [build-rc]
       trigger: true
     - get: unit-image
-      passed: [build-rc]
-      trigger: true
     - get: ci
   - task: terraform-smoke
     image: unit-image
@@ -749,7 +728,6 @@ jobs:
       passed: [build-rc-image]
       trigger: true
     - get: unit-image
-      passed: [build-rc-image]
     - get: ci
     - get: docs
   - task: quickstart-smoke
@@ -771,8 +749,6 @@ jobs:
       passed: [bin-smoke]
       trigger: true
     - get: unit-image
-      passed: [bin-smoke]
-      trigger: true
     - get: version
       passed: [bin-smoke]
       trigger: true
@@ -797,8 +773,6 @@ jobs:
       passed: [bosh-check-props]
       trigger: true
     - get: unit-image
-      passed: [bosh-check-props]
-      trigger: true
     - get: version
       passed: [bosh-check-props]
     - get: linux-rc-ubuntu
@@ -828,7 +802,6 @@ jobs:
     - get: concourse
       passed: [bosh-bump]
     - get: unit-image
-      passed: [bosh-bump]
     - get: version
       passed: [bosh-bump]
     - get: concourse-release
@@ -878,7 +851,6 @@ jobs:
     - get: concourse
       passed: [bosh-bump]
     - get: unit-image
-      passed: [bosh-bump]
     - get: version
       passed: [bosh-bump]
     - get: concourse-release


### PR DESCRIPTION
Previously, in order to have a job in the pipeline to leverage an
updated `unit-image`, you'd need to have the whole pipeline successfully
run in order to benefit from that update.

That made the iteration slow.

By adopting the same pattern as `ci`, we're able to independently update
`unit-image`, just like `ci`.

![Screen Shot 2019-08-15 at 10 45 27 AM](https://user-images.githubusercontent.com/3574444/63102836-da730680-bf49-11e9-9ec8-e959719f666c.png)


Wdyt?

Thanks!