### PR TITLE
release: pin charts version to match Charts' concourse versions

### DIFF
--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -75,6 +75,7 @@ jobs:
         vars:
           release_major: "5"
           release_minor: "5.2"
+          charts_version: '060b57708ed34ffd47f8076bf5906167dfce96b8'
           concourse_smoke_deployment_name: "concourse-smoke-5-2"
           use_external_linker: true
       - name: release-5.3.x
@@ -83,6 +84,7 @@ jobs:
         vars:
           release_major: "5"
           release_minor: "5.3"
+          charts_version: 'f3dde5b4c00ea44c0684afcf154858032c703a40'
           concourse_smoke_deployment_name: "concourse-smoke-5-3"
           use_external_linker: true
       - name: release-5.4.x
@@ -91,6 +93,7 @@ jobs:
         vars:
           release_major: "5"
           release_minor: "5.4"
+          charts_version: '060b57708ed34ffd47f8076bf5906167dfce96b8'
           concourse_smoke_deployment_name: "concourse-smoke-5-4"
           use_external_linker: false
       - name: concourse

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -2,6 +2,8 @@
 #
 #   ((release_major))                   the MAJOR version, e.g. 5
 #   ((release_minor))                   the MAJOR.MINOR version, e.g. 5.1
+#   ((charts_version))                  the commit on `helm/charts` where the version of
+#                                       concourse matches the desired release version
 #   ((concourse_smoke_deployment_name)) a unique name for the smoke bosh deployment
 #   ((use_external_linker))             whether to use an external linker for go builds;
 #                                       otherwise the built-in go linker will be used.
@@ -326,7 +328,6 @@ jobs:
       passed: [build-rc-image]
       trigger: true
     - get: charts
-      trigger: true
     - get: ci
   - task: check-params
     file: ci/tasks/check-distribution-env.yml
@@ -352,7 +353,6 @@ jobs:
       passed: [build-rc-image]
       trigger: true
     - get: charts
-      trigger: true
     - get: unit-image
       passed: [build-rc-image]
     - get: ci
@@ -1088,6 +1088,7 @@ resources:
 - name: charts
   type: git
   icon: *git-icon
+  version: {ref: ((charts_version))}
   source:
     uri: https://github.com/helm/charts.git
     branch: master


### PR DESCRIPTION
As the Chart contains the fields that are specified for any given
version (e.g., `master` currently points to 5.4.1), when leveraging
`branch: master` in the release pipeline for 5.2., we end up with
problems given that the fields differ.

Thus, this commit pins the version of `helm/charts` to the last commit
where the version of Concourse appropriately matches.

Thanks!