### PR TITLE
concourse: fix installation of `gdn` to not include version

### DIFF
--- a/tasks/scripts/concourse-build
+++ b/tasks/scripts/concourse-build
@@ -39,7 +39,7 @@ mkdir $output/concourse
 bin=$output/concourse/bin
 mkdir $bin
 mv concourse/concourse $bin
-[ -d gdn ] && cp gdn/gdn* $bin
+[ -d gdn ] && install -m 0755 gdn/gdn* $bin/gdn
 
 [ -d resource-types ] && cp -a resource-types $output/concourse
 


### PR DESCRIPTION
This is intended to fix the problem that https://github.com/concourse/ci/pull/98 introduced when putting `gdn` to be fetched directly from the `gdn` github-release in the `build-rc` step: rather than coming named as `gdn`, it now comes as `gdn-$VERSION`.

As in later steps we trust that guardian is well-named (i.e., named `gdn`) and is executable, we used to make any jobs after `build-rc` fail.
