### PR TITLE
concourse/#4302 updating dev/unit base image to golang-builder

### DIFF
--- a/dockerfiles/dev/Dockerfile
+++ b/dockerfiles/dev/Dockerfile
@@ -6,7 +6,7 @@
 # * warming the module cache
 # * warming the build cache
 
-FROM golang:1
+FROM concourse/golang-builder
 
 RUN apt-get update && apt-get -y install \
       iproute2 \

--- a/dockerfiles/unit/Dockerfile
+++ b/dockerfiles/unit/Dockerfile
@@ -1,15 +1,17 @@
-FROM golang:1
+FROM concourse/golang-builder
 
 # basic setup for adding new apt sources and installing packages
 RUN apt-get update && apt-get -y install \
       apt-transport-https \
       ca-certificates \
       curl \
+      iproute2 \
       gnupg2 \
       software-properties-common \
       unzip
 
 # install PostgreSQL for DB tests
+ENV DEBIAN_FRONTEND noninteractive
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main"
 RUN apt-get update && apt-get -y install postgresql-11
@@ -26,7 +28,7 @@ RUN apt-get update && apt-get -y install yarn
 
 # install Docker
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 RUN apt-get update && apt-get -y install docker-ce
 
 # install Docker Compose

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -53,7 +53,7 @@ groups:
   jobs:
   - resource-types-images
   - unit-image
-  - golang-builder-image
+  - build-golang-builder-image
 
 - name: publish
   jobs:
@@ -79,6 +79,10 @@ jobs:
   - in_parallel:
     - get: ci
     - get: builder
+    - get: golang-builder-trigger
+      trigger: true
+      params:
+        skip_download: true
   - task: build
     image: builder
     privileged: true
@@ -114,7 +118,7 @@ jobs:
         mode: normal
         alert_type: broke
 
-- name: golang-builder-image
+- name: build-golang-builder-image
   public: true
   serial: true
   plan:
@@ -248,6 +252,10 @@ jobs:
         trigger: true
       - get: unit-image
         trigger: true
+      - get: golang-builder-trigger
+        trigger: true
+        params:
+          skip_download: true
       - get: gdn
         trigger: true
       - get: dumb-init
@@ -1341,6 +1349,14 @@ resources:
 
 - name: golang-builder-image
   type: registry-image
+  icon: *image-icon
+  source:
+    repository: concourse/golang-builder
+    username: ((docker.username))
+    password: ((docker.password))
+
+- name: golang-builder-trigger
+  type: docker-image
   icon: *image-icon
   source:
     repository: concourse/golang-builder


### PR DESCRIPTION
Update `concourse/unit` and `concourse/dev` to use the `concourse/golang-builder` as they previously were based on the official golang image which had a major bump from `stretch` to `buster`. 

The main concourse pipeline experienced high CPU usage as well as timeouts for tests that utilized the `buster` variant.

Fixes concourse/concourse#4302
Co-authored-by: Krishna Mannem <kmannem@pivotal.io>