### PR TITLE
fix task to generate dpkg list file

### DIFF
--- a/tasks/generate-dpkg-list.yml
+++ b/tasks/generate-dpkg-list.yml
@@ -25,4 +25,4 @@ run:
         VERSION=$(cat ./version/version)
       fi
 
-      dpkg -l > ./dpkg-list/${COMPONENT_NAME}-${VERSION}.txt
+      dpkg -l > ./dpkg-list/${COMPONENT_NAME}-dpkg-list-${VERSION}.txt


### PR DESCRIPTION
Previously (in https://github.com/concourse/ci/pull/122), we forgot to have the `dpkg-list` sentence in the middle of the name like how we do for the resources: 

https://github.com/concourse/ci/blob/273ca6e2254f62ef611cb3d827166b66c688494a/pipelines/resources/template.jsonnet#L164

While that would not break the pipeline, it would make the bucket have an inconsistency in the nomenclature.
