### PR TITLE
removing k8s constraints from final-version and concourse-rc-image

### DIFF
--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -820,7 +820,6 @@ jobs:
     params: {bump: final}
     passed:
     - build-rc
-    - k8s-topgun
     - bosh-smoke
     - bosh-topgun
   - get: linux-rc
@@ -834,7 +833,6 @@ jobs:
   - get: concourse-rc-image
     passed: [k8s-topgun]
   - get: concourse-rc-image-ubuntu
-    passed: [k8s-topgun]
   - get: concourse-release
     passed: [bosh-smoke, bosh-topgun]
   - get: bpm-release


### PR DESCRIPTION
just trying to get the release 5.2.x and 5.4.x going

Signed-off-by: James Thomson <jthomson@pivotal.io>