### PR TITLE
rolling golang-builder back to xenial

### DIFF
--- a/dockerfiles/golang-builder/Dockerfile
+++ b/dockerfiles/golang-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:xenial
 
 # gcc for cgo
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Signed-off-by: Jamie Klassen <cklassen@pivotal.io>
Co-authored-by: Krishna Mannem <kmannem@pivotal.io>