### PR TITLE
add dumb-init to dev image via resource

### DIFF
--- a/dockerfiles/dev/Dockerfile
+++ b/dockerfiles/dev/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && apt-get -y install \
       ca-certificates \
       file \
       btrfs-tools \
-      dumb-init
+
+COPY dumb-init/dumb-init_*_amd64 /usr/local/bin/dumb-init
 
 # add and install executable dependencies
 COPY gdn/gdn-* /usr/local/concourse/bin/gdn

--- a/tasks/build-dev-image.yml
+++ b/tasks/build-dev-image.yml
@@ -11,6 +11,7 @@ params:
 
 inputs:
 - name: ci
+- name: dumb-init
 - name: concourse
 - name: gdn
 - name: resource-types-image


### PR DESCRIPTION
instead of installing from APT repository during building