### PR TITLE
release: make `bosh-bump` trigger on new version

### DIFF
--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -684,6 +684,7 @@ jobs:
       trigger: true
     - get: unit-image
     - get: version
+      trigger: true
       passed: [bosh-check-props]
     - get: linux-rc-ubuntu
       passed: [build-rc, bosh-check-props]


### PR DESCRIPTION
While usually we do have changes coming along that would trigger
bosh-bump, in the case of a fix that is related just to `ci`, and we're
building a new version, because `ci` is really not supposed to trigger,
`version` seems to be the second next good thing to trigger on.
