### PR TITLE
temporarily replace `apache` go mod dependency

### DIFF
--- a/tasks/scripts/k8s-topgun
+++ b/tasks/scripts/k8s-topgun
@@ -20,6 +20,11 @@ export CHARTS_DIR="$(realpath ./charts)"
 
 cd concourse
 
+# [cc] temporarily replace the location of the transitive dependency
+# `thrift` so that `go` can reach a git server (that is online at the
+# moment - lol) hosting what we need.
+#
+echo "replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999" >> ./go.mod
 go mod download
 
 go install github.com/onsi/ginkgo/ginkgo

--- a/tasks/scripts/topgun
+++ b/tasks/scripts/topgun
@@ -30,6 +30,11 @@ install ./releases/bbr /usr/local/bin/
 
 cd concourse
 
+# [cc] temporarily replace the location of the transitive dependency
+# `thrift` so that `go` can reach a git server (that is online at the
+# moment - lol) hosting what we need.
+#
+echo "replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999" >> ./go.mod
 go mod download
 
 go install github.com/onsi/ginkgo/ginkgo


### PR DESCRIPTION
As of literally right now (Sat 31 Aug 2019 20:02:43 EDT), git.apache.org
is facing troubles, and is not expected to get up very soon.

To get around that, this PR sneaks in a replacement directive that
modifies the source of the thrift code when we're fetching dependencies
to run our tests.

Note.: this is meant to be TEMPORARILY (like, really temporarily - an
issue to revert it when they get back up again was created).

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>