### PR TITLE
remove label so semver prs will be tested

### DIFF
--- a/pipelines/resources/template.jsonnet
+++ b/pipelines/resources/template.jsonnet
@@ -427,8 +427,7 @@ local build_image(distro) = {
       source: {
         repo: "concourse/"+resource+"-resource",
         base: "master",
-        access_token: "((pull_requests_access_token))",
-        [if resource == "s3" || resource == "semver" then "label"]: "approved-for-ci"
+        access_token: "((pull_requests_access_token))"
       }
     },
     {


### PR DESCRIPTION
having an approved-for-ci label on the semver resource prevented pr tests to run