### PR TITLE
fix upgrade/downgrade verify script

### DIFF
--- a/tasks/scripts/verify-upgrade-downgrade-pipeline
+++ b/tasks/scripts/verify-upgrade-downgrade-pipeline
@@ -50,4 +50,4 @@ fly -t local builds \
 
 # test that we can check our resources
 fly -t local check-resource -r "test-pipeline/test-resource" \
-  | grep "checked"
+  | grep "test-resource.*succeeded"


### PR DESCRIPTION
due to merging of lidar the `fly check-resource` changed its output from `checked` to `CHECK_ID RESOURCE_NAME STATUS`