### PR TITLE
pass release-notes-only changes even faster

### DIFF
--- a/tasks/docker-compose-testflight.yml
+++ b/tasks/docker-compose-testflight.yml
@@ -20,5 +20,7 @@ params:
   BUILD:
 
 run:
-  path: ci/tasks/scripts/with-docker-compose
-  args: [ci/tasks/scripts/testflight]
+  path: ci/tasks/scripts/pass-release-notes-only-change
+  args:
+  - ci/tasks/scripts/with-docker-compose
+  - ci/tasks/scripts/testflight

--- a/tasks/docker-compose-watsjs.yml
+++ b/tasks/docker-compose-watsjs.yml
@@ -21,5 +21,7 @@ params:
   BUILD:
 
 run:
-  path: ci/tasks/scripts/with-docker-compose
-  args: [ci/tasks/scripts/watsjs]
+  path: ci/tasks/scripts/pass-release-notes-only-change
+  args:
+  - ci/tasks/scripts/with-docker-compose
+  - ci/tasks/scripts/watsjs

--- a/tasks/scripts/pass-release-notes-only-change
+++ b/tasks/scripts/pass-release-notes-only-change
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ -f concourse/.git/resource/changed_files ]; then
+  grep -v release-notes concourse/.git/resource/changed_files || {
+    echo 'skipping testing for release-notes-only change'
+    exit 0
+  }
+fi
+
+"$@"

--- a/tasks/scripts/testflight
+++ b/tasks/scripts/testflight
@@ -8,13 +8,6 @@ export PATH=$GOPATH/bin:$PATH
 
 cd concourse
 
-if [ -f .git/resource/changed_files ]; then
-  grep -v release-notes .git/resource/changed_files || {
-    echo 'skipping testing for release-notes-only change'
-    exit 0
-  }
-fi
-
 go mod download
 
 go install github.com/onsi/ginkgo/ginkgo

--- a/tasks/scripts/unit
+++ b/tasks/scripts/unit
@@ -6,15 +6,6 @@ set -e -u
 export GOPATH=$PWD/gopath
 export PATH=$GOPATH/bin:$PATH
 
-cd concourse
-
-if [ -f .git/resource/changed_files ]; then
-  grep -v release-notes .git/resource/changed_files || {
-    echo 'skipping testing for release-notes-only change'
-    exit 0
-  }
-fi
-
 mkdir /tmp/concourse-pg-runner
 if ! mount -t tmpfs none /tmp/concourse-pg-runner 2>/dev/null; then
   if grep '/dev/shm.*tmpfs' /proc/mounts >/dev/null; then
@@ -26,6 +17,7 @@ if ! mount -t tmpfs none /tmp/concourse-pg-runner 2>/dev/null; then
   fi
 fi
 
+cd concourse
 
 go mod download
 

--- a/tasks/scripts/watsjs
+++ b/tasks/scripts/watsjs
@@ -5,13 +5,6 @@ set -e
 
 cd concourse
 
-if [ -f .git/resource/changed_files ]; then
-  grep -v release-notes .git/resource/changed_files || {
-    echo 'skipping testing for release-notes-only change'
-    exit 0
-  }
-fi
-
 # check if smoke tests already downloaded fly
 if ! [ -e /usr/local/bin/fly ]; then
   go install ./fly

--- a/tasks/unit.yml
+++ b/tasks/unit.yml
@@ -13,4 +13,5 @@ caches:
 - path: gopath
 
 run:
-  path: ci/tasks/scripts/unit
+  path: ci/tasks/scripts/pass-release-notes-only-change
+  args: [ci/tasks/scripts/unit]


### PR DESCRIPTION
no need to spin up and tear down docker if you're not testing any code!