### PR TITLE
fix `pass-release-notes-only yarn-build` to have output

### DIFF
--- a/tasks/scripts/pass-release-notes-only-change
+++ b/tasks/scripts/pass-release-notes-only-change
@@ -3,6 +3,7 @@
 if [ -f concourse/.git/resource/changed_files ]; then
   grep -v release-notes concourse/.git/resource/changed_files || {
     echo 'skipping testing for release-notes-only change'
+    cp -rT concourse built-concourse
     exit 0
   }
 fi


### PR DESCRIPTION
I noticed some strange failures in testflight and watjs, like:
https://ci.concourse-ci.org/teams/main/pipelines/prs/jobs/watsjs/builds/1939#L5d8511f1:39

I discovered that in those two jobs, the output of `yarn-build` was being
passed to the task in question, and since making yarn-build a noop in #172, it
no longer had valid output. This PR should fix it!