### PR TITLE
remove unused dependency for the windows worker on Concourse

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -1293,8 +1293,6 @@ jobs:
   serial: true
   plan:
   - in_parallel:
-    - get: concourse
-      params: {submodules: none}
     - get: golang-windows
     - get: ci
   - task: install-go


### PR DESCRIPTION
we noticed we are doing a get on Concourse without using it as a dependency.