### PR TITLE
notify on build-rc-image broke/fixed

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -702,6 +702,8 @@ jobs:
           params:
             image: image-ubuntu/image.tar
             additional_tags: version/version
+  on_success: *fixed-concourse
+  on_failure: *broke-concourse
 
 - name: bin-smoke
   public: true

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -617,6 +617,8 @@ jobs:
           params:
             image: image-ubuntu/image.tar
             additional_tags: version/version
+  on_success: *fixed-concourse
+  on_failure: *broke-concourse
 
 - name: bin-smoke
   public: true


### PR DESCRIPTION
hopefully this will tell us whether concourse/concourse-docker#52 caused any issues.