### PR TITLE
add `k8s-topgun` tag and `IN_CLUSTER` param to k8s-topgun

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -464,27 +464,36 @@ jobs:
   - in_parallel:
     - get: concourse
       passed: [k8s-smoke]
+      tags: [k8s-topgun]
       trigger: true
     - get: version
       passed: [k8s-smoke]
+      tags: [k8s-topgun]
       trigger: true
     - get: concourse-rc-image
-      passed: [k8s-smoke]
-      trigger: true
       params: {format: oci}
+      passed: [k8s-smoke]
+      tags: [k8s-topgun]
+      trigger: true
     - get: concourse-rc-image-ubuntu
-      passed: [k8s-smoke]
-      trigger: true
       params: {format: oci}
-    - get: unit-image
-    - get: charts
-      trigger: true
       passed: [k8s-smoke]
+      tags: [k8s-topgun]
+      trigger: true
+    - get: unit-image
+      tags: [k8s-topgun]
+    - get: charts
+      passed: [k8s-smoke]
+      tags: [k8s-topgun]
+      trigger: true
     - get: ci
+      tags: [k8s-topgun]
   - task: k8s-topgun
     file: ci/tasks/k8s-topgun.yml
+    tags: [k8s-topgun]
     image: unit-image
     params:
+      IN_CLUSTER: "true"
       KUBE_CONFIG: ((kube_config))
       CONCOURSE_IMAGE_NAME: concourse/concourse-rc
   on_success: *fixed-concourse

--- a/tasks/scripts/k8s-topgun
+++ b/tasks/scripts/k8s-topgun
@@ -24,4 +24,4 @@ go mod download
 
 go install github.com/onsi/ginkgo/ginkgo
 
-ginkgo -nodes=4 -race -keepGoing -slowSpecThreshold=300 -skip="$SKIP" ./topgun/k8s/ "$@"
+ginkgo -nodes=8 -race -keepGoing -slowSpecThreshold=900 -flakeAttempts=3 -skip="$SKIP" ./topgun/k8s/ "$@"


### PR DESCRIPTION
After https://github.com/concourse/concourse/pull/4643, we're not able
to leverage the `IN_CLUSTER` environment variable, which switches the
behavior of using `port-forward` to reach endpoints by actually just
using the internal addresses of those.

Tagging the steps as `k8s-topgun` lets us be inside the cluster, making
`IN_CLUSTER` possible.

---

~update: we're finishing this off by doing acceptance with `fly execute` - will remove `wip:` afterwards~ ready!