### PR TITLE
[fix concourse-ops#117] Concourse chart repo build pipeline

### DIFF
--- a/pipelines/concourse-chart-repo-build.yml
+++ b/pipelines/concourse-chart-repo-build.yml
@@ -11,15 +11,84 @@ resources:
     bucket: concourse-chart
     json_key: ((concourse_chart_bucket_json_key))
     regexp: ".*"
+- name: helm-charts
+  type: git
+  icon: github-circle
+  source:
+    uri: https://github.com/helm/charts.git
+    branch: master
 - name: concourse-chart
   type: git
   source:
     uri: https://github.com/concourse/concourse-chart
+    branch: ((chart_release_branch))
+- name: concourse
+  type: git
+  icon: github-circle
+  source:
+    uri: https://github.com/concourse/concourse.git
+    branch: master
+- name: concourse-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: concourse/concourse
+    username: ((docker.username))
+    password: ((docker.password))
+- name: ci
+  type: git
+  icon: github-circle
+  source:
+    uri: https://github.com/concourse/ci.git
+    branch: master
+- name: unit-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: concourse/unit
+    username: ((docker.username))
+    password: ((docker.password))
+
 jobs:
+- name: k8s-topgun
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: concourse-chart
+      tags: [pr]
+    - get: helm-charts
+      tags: [pr]
+    - get: concourse
+      tags: [pr]
+    - get: concourse-image
+      tags: [pr]
+    - get: ci
+      tags: [pr]
+    - get: unit-image
+      tags: [pr]
+    params: {path: chart-pr, status: pending, context: k8s-topgun}
+    get_params: {list_changed_files: true}
+    tags: [pr]
+  - task: k8s-topgun
+    tags: [pr]
+    file: ci/tasks/k8s-topgun.yml
+    input_mapping:
+      concourse-chart: chart-pr
+      concourse-rc-image: concourse-image
+    image: unit-image
+    params:
+      KUBE_CONFIG: ((topgun_kube_config))
+      CONCOURSE_IMAGE_NAME: concourse/concourse
+      GINKGO_FOCUS_ON: "Worker lifecycle"
 - name: build-chart
   public: true
   plan:
   - get: concourse-chart
+    passed: [k8s-topgun]
+  - get: chart-repo-store
+    params:
+      filename: index.yaml
   - task: build
     config:
       platform: linux
@@ -38,8 +107,7 @@ jobs:
           helm repo remove local
           helm repo update
           helm package -u -d $DESTINATION_DIR $CHART_NAME
-          helm repo index $DESTINATION_DIR
-
+          helm repo index --merge chart-repo-store/index.yaml $DESTINATION_DIR
       inputs:
       - name: concourse-chart
       outputs:

--- a/pipelines/concourse-chart-repo-build.yml
+++ b/pipelines/concourse-chart-repo-build.yml
@@ -1,0 +1,54 @@
+resource_types:
+- name: gcs-resource
+  type: docker-image
+  source:
+    repository: frodenas/gcs-resource
+
+resources:
+- name: chart-repo-store
+  type: gcs-resource
+  source:
+    bucket: concourse-chart
+    json_key: ((concourse_chart_bucket_json_key))
+    regexp: ".*"
+- name: concourse-chart
+  type: git
+  source:
+    uri: https://github.com/concourse/concourse-chart
+    branch: chart-name
+jobs:
+- name: build-chart
+  public: true
+  plan:
+  - get: concourse-chart
+  - task: build
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: cirocosta/charts-maintenance
+      run:
+        path: sh
+        args:
+        - -ceu
+        - |
+          helm init --client-only
+          helm repo remove local
+          helm repo update
+          helm package -u -d $DESTINATION_DIR $CHART_DIR
+          helm repo index $DESTINATION_DIR
+
+      inputs:
+      - name: concourse-chart
+      outputs:
+      - name: repository
+    params:
+      CHART_DIR: ./concourse-chart
+      DESTINATION_DIR: ./repository
+  - put: chart-repo-store
+    params:
+      file: repository/index.yaml
+  - put: chart-repo-store
+    params:
+      file: repository/*.tgz

--- a/pipelines/concourse-chart-repo-build.yml
+++ b/pipelines/concourse-chart-repo-build.yml
@@ -15,7 +15,6 @@ resources:
   type: git
   source:
     uri: https://github.com/concourse/concourse-chart
-    branch: chart-name
 jobs:
 - name: build-chart
   public: true
@@ -33,10 +32,12 @@ jobs:
         args:
         - -ceu
         - |
+          mkdir $CHART_NAME
+          mv $CHART_DIR/* $CHART_NAME/
           helm init --client-only
           helm repo remove local
           helm repo update
-          helm package -u -d $DESTINATION_DIR $CHART_DIR
+          helm package -u -d $DESTINATION_DIR $CHART_NAME
           helm repo index $DESTINATION_DIR
 
       inputs:
@@ -44,6 +45,7 @@ jobs:
       outputs:
       - name: repository
     params:
+      CHART_NAME: concourse
       CHART_DIR: ./concourse-chart
       DESTINATION_DIR: ./repository
   - put: chart-repo-store


### PR DESCRIPTION
add a pipeline for building the concourse repo that is hosted on gcs.

- This pipeline updates the repo (bucket `concourse-chart`) against the chart source code https://github.com/concourse/concourse-chart.
- variable `concourse_chart_bucket_json_key` should be set before setup the pipeline.
- A workaround for chart name due to helm v2 require the chart name to be identical to the folder name. This is fixed in helm v3.