### PR TITLE
Release branch improvements

### DIFF
--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -91,26 +91,6 @@ jobs:
           charts_version: '060b57708ed34ffd47f8076bf5906167dfce96b8'
           concourse_smoke_deployment_name: "concourse-smoke-5-2"
           use_external_linker: true
-      - name: release-5.3.x
-        team: main
-        exposed: true
-        config_file: pipelines/pipelines/release.yml
-        vars:
-          release_major: "5"
-          release_minor: "5.3"
-          charts_version: 'f3dde5b4c00ea44c0684afcf154858032c703a40'
-          concourse_smoke_deployment_name: "concourse-smoke-5-3"
-          use_external_linker: true
-      - name: release-5.4.x
-        team: main
-        exposed: true
-        config_file: pipelines/pipelines/release.yml
-        vars:
-          release_major: "5"
-          release_minor: "5.4"
-          charts_version: '060b57708ed34ffd47f8076bf5906167dfce96b8'
-          concourse_smoke_deployment_name: "concourse-smoke-5-4"
-          use_external_linker: false
       - name: release-5.5.x
         team: main
         exposed: true
@@ -120,16 +100,6 @@ jobs:
           release_minor: "5.5"
           charts_version: '96c33a23657b63630220b085e763f26862ac9ff3'
           concourse_smoke_deployment_name: "concourse-smoke-5-5"
-          use_external_linker: false
-      - name: release-5.6.x
-        team: main
-        exposed: true
-        config_file: pipelines/pipelines/release.yml
-        vars:
-          release_major: "5"
-          release_minor: "5.6"
-          charts_version: '5a33da9adf31ee802ca6e1247b0b5fdac2bb9aca'
-          concourse_smoke_deployment_name: "concourse-smoke-5-6"
           use_external_linker: false
       - name: release-5.7.x
         team: main

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -88,7 +88,6 @@ jobs:
         vars:
           release_major: "5"
           release_minor: "5.2"
-          charts_version: '060b57708ed34ffd47f8076bf5906167dfce96b8'
           concourse_smoke_deployment_name: "concourse-smoke-5-2"
           use_external_linker: true
       - name: release-5.5.x
@@ -98,7 +97,6 @@ jobs:
         vars:
           release_major: "5"
           release_minor: "5.5"
-          charts_version: '96c33a23657b63630220b085e763f26862ac9ff3'
           concourse_smoke_deployment_name: "concourse-smoke-5-5"
           use_external_linker: false
       - name: release-5.7.x
@@ -108,7 +106,6 @@ jobs:
         vars:
           release_major: "5"
           release_minor: "5.7"
-          charts_version: '1d5c61dd5ddb04fe4b159bc52d09ae8dbded9347'
           concourse_smoke_deployment_name: "concourse-smoke-5-7"
           use_external_linker: false
       - name: algorithm-v3

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -31,7 +31,7 @@ resources:
   type: concourse-pipeline
   icon: pipe
   source:
-    target: https://ci.concourse-ci.org
+    target: https://nci.concourse-ci.org
     teams:
     - name: main
       username: ((basic_auth.username))

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -2,7 +2,6 @@
 #
 #   ((release_major))                   the MAJOR version, e.g. 5
 #   ((release_minor))                   the MAJOR.MINOR version, e.g. 5.1
-#   ((charts_version))                  the commit on `helm/charts` where the version of
 #                                       concourse matches the desired release version
 #   ((concourse_smoke_deployment_name)) a unique name for the smoke bosh deployment
 #   ((use_external_linker))             whether to use an external linker for go builds;
@@ -12,7 +11,6 @@
 #
 #   concourse/concourse                 release/((release_minor)).x
 #   concourse/concourse-bosh-release    release/((release_minor)).x
-#   concourse/concourse-bosh-deployment release/((release_minor)).x
 #
 # everything else will be managed by the pipeline
 
@@ -1214,10 +1212,9 @@ resources:
 - name: charts
   type: git
   icon: *git-icon
-  version: {ref: ((charts_version))}
   source:
-    uri: https://github.com/helm/charts.git
-    branch: master
+    uri: https://github.com/concourse/concourse-chart.git
+    branch: release/((release_minor)).x
 
 - name: concourse-github-release
   type: github-release


### PR DESCRIPTION
Get rid of minor versions we don't support anymore in the `reconfigure` pipeline-setting logic, and use branches rather than master commit SHAs for concourse/concourse-charts.