### PR TITLE
Use IP address instead of dns to reach bosh-smoke deployment

### DIFF
--- a/tasks/scripts/discover-bosh-endpoint-info
+++ b/tasks/scripts/discover-bosh-endpoint-info
@@ -6,5 +6,5 @@ set -e
 # print once just to see useful output in CI
 bosh instances --dns
 
-bosh instances --dns | grep "${BOSH_INSTANCE_GROUP}/" | awk '{print $5}' | head -n1 \
+bosh instances --dns | grep "${BOSH_INSTANCE_GROUP}/" | awk '{print $4}' | head -n1 \
   > endpoint-info/instance_ip


### PR DESCRIPTION
For some reason, the bbl environment we're using doesn't assign DNS A
records to our instances. Instead, we'll use the IP that is assigned to
the instance.

The instance output used to look like this on prod

```
Instance                                        Process State  AZ  IPs          DNS A Records

concourse/36c718c8-40b4-4e16-bb53-7850e4bf2168  running        z1  10.244.0.11  36c718c8-40b4-4e16-bb53-7850e4bf2168.concourse.test.concourse-smoke-5-7.bosh
```

Now it looks like this on the bbl environment

```
Instance                                        Process State  AZ  IPs       DNS A Records

concourse/2e10e557-80b1-48e5-b863-fc3c4b465f70  running        z1  10.0.1.1  -
```

We `grep` this output to get the IP address.