### PR TITLE
Tag smoke-deployment resource to run on the topgun worker

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -1823,6 +1823,7 @@ resources:
     private_key: ((concourse_release_deploy_key))
 
 - name: smoke-deployment
+  tags: [topgun]
   type: bosh-deployment
   icon: fire
   source:

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -1206,6 +1206,7 @@ resources:
     private_key: ((concourse_release_deploy_key))
 
 - name: smoke-deployment
+  tags: [topgun]
   type: bosh-deployment
   icon: fire
   source:


### PR DESCRIPTION
Missed this change when making https://github.com/concourse/ci/pull/205

Without this, the resource check fails. Doesn't functionally affect the pipeline or ability to release.