### PR TITLE
reconfigure: add `resources` team

### DIFF
--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -36,6 +36,9 @@ resources:
     - name: main
       username: ((basic_auth.username))
       password: ((basic_auth.password))
+    - name: resources
+      username: ((basic_auth.username))
+      password: ((basic_auth.password))
 
 jobs:
 - name: reconfigure-resource-pipelines
@@ -62,7 +65,7 @@ jobs:
         pool
         datadog-event
         mock
-  - put : prod
+  - put: prod
     inputs: [rendered_pipelines]
     params:
       pipelines:


### PR DESCRIPTION
without having the `team` added to the `source`, it'd always fail with
the early checks that it perform:

	Logging to /tmp/concourse-pipeline-resource-out.log000647387

	2019/11/20 14:55:22 team name 'resources' not found in source team
	names: [main]

see https://github.com/concourse/concourse-pipeline-resource#source-configuration

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>