### PR TITLE
Removing the concourse-chart pipeline from reconfigure

### DIFF
--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -13,20 +13,6 @@ resources:
     paths:
     - pipelines
 
-- name: charts-maintenance
-  type: git
-  icon: github-circle
-  source:
-    uri: https://github.com/concourse/charts
-    branch: maintenance
-
-- name: maintenance-image
-  type: registry-image
-  source:
-    password: ((docker.password))
-    repository: concourse/charts-maintenance
-    username: ((docker.username))
-
 - name: prod
   type: concourse-pipeline
   icon: pipe
@@ -155,9 +141,6 @@ jobs:
       - name: wings
         team: main
         config_file: pipelines/pipelines/wings.yml
-      - name: concourse-charts
-        team: main
-        config_file: charts-maintenance/pipeline.yml
       - name: norsk-mirror
         team: main
         config_file: pipelines/pipelines/norsk-mirror.yml


### PR DESCRIPTION
This PR removes the `concourse-chart` pipeline from the `reconfigure` pipeline.
Don't need this old chart infrastructure since we're
maintaining the chart in our own repo now.