### PR TITLE
Revert "get release notes for patches from release branch"

### DIFF
--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -1014,7 +1014,7 @@ resources:
   icon: *git-icon
   source:
     uri: https://github.com/concourse/concourse.git
-    branch: release/((release_minor)).x
+    branch: master
     paths:
     - release-notes/
 


### PR DESCRIPTION
So master will be the only source of truth of all release notes. In individual release branch of `concourse` there is no need to keep release notes up to date.