### PR TITLE
Update helm-pr pipeline for new concourse-chart repo

### DIFF
--- a/pipelines/helm-prs.yml
+++ b/pipelines/helm-prs.yml
@@ -10,6 +10,7 @@ resources:
   icon: source-pull
   source:
     repository: concourse/concourse-chart
+    base_branch: ((pr_base_branch))
     access_token: ((pr_access_token))
 
 - name: helm-charts
@@ -24,7 +25,7 @@ resources:
   icon: github-circle
   source:
     uri: https://github.com/concourse/concourse.git
-    branch: master
+    branch: ((concourse_base_branch))
 
 - name: ci
   type: git
@@ -33,11 +34,12 @@ resources:
     uri: https://github.com/concourse/ci.git
     branch: master
 
-- name: concourse-rc-image
+- name: concourse-image
   type: registry-image
   icon: docker
   source:
-    repository: concourse/concourse-rc
+    repository: concourse/concourse
+    tag: ((concourse_image_tag))
     username: ((docker.username))
     password: ((docker.password))
 
@@ -53,29 +55,43 @@ jobs:
 - name: k8s-topgun
   serial: true
   public: true
+  on_failure:
+    put: chart-pr
+    inputs: [chart-pr]
+    params: {path: chart-pr, status: failure, context: k8s-topgun}
+    tags: [k8s-topgun]
+  on_success:
+    put: chart-pr
+    inputs: [chart-pr]
+    params: {path: chart-pr, status: success, context: k8s-topgun}
+    tags: [k8s-topgun]
   plan:
   - in_parallel:
     - get: chart-pr
+      tags: [k8s-topgun]
     - get: helm-charts
+      tags: [k8s-topgun]
     - get: concourse
-    - get: concourse-rc-image
+      tags: [k8s-topgun]
+    - get: concourse-image
+      tags: [k8s-topgun]
     - get: ci
+      tags: [k8s-topgun]
     - get: unit-image
+      tags: [k8s-topgun]
+  - put: chart-pr
+    inputs: [chart-pr]
+    params: {path: chart-pr, status: pending, context: k8s-topgun}
+    get_params: {list_changed_files: true}
+    tags: [k8s-topgun]
   - task: k8s-topgun
+    tags: [k8s-topgun]
     file: ci/tasks/k8s-topgun.yml
     input_mapping:
       concourse-chart: chart-pr
+      concourse-rc-image: concourse-image
     image: unit-image
     params:
-      KUBE_CONFIG: ((kube_config))
-      CONCOURSE_IMAGE_NAME: concourse/concourse-rc
-    on_success:
-      put: chart-pr
-      params:
-        path: chart-pr
-        comment: "Topgun tests passed: $ATC_EXTERNAL_URL/builds/$BUILD_ID"
-    on_failure:
-      put: chart-pr
-      params:
-        path: chart-pr
-        comment: "Topgun tests failed: $ATC_EXTERNAL_URL/builds/$BUILD_ID"
+      IN_CLUSTER: "true"
+      KUBE_CONFIG: ((topgun_kube_config))
+      CONCOURSE_IMAGE_NAME: concourse/concourse

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -13,20 +13,6 @@ resources:
     paths:
     - pipelines
 
-- name: charts-maintenance
-  type: git
-  icon: github-circle
-  source:
-    uri: https://github.com/concourse/charts
-    branch: maintenance
-
-- name: maintenance-image
-  type: registry-image
-  source:
-    password: ((docker.password))
-    repository: concourse/charts-maintenance
-    username: ((docker.username))
-
 - name: ruby-alpine-image
   type: registry-image
   source:
@@ -137,21 +123,6 @@ jobs:
   plan:
   - get: pipelines
     trigger: true
-  - get: charts-maintenance
-    trigger: true
-  - get: maintenance-image
-  - task: generate-charts-yaml
-    image: maintenance-image
-    config:
-      platform: linux
-      inputs:
-      - name: charts-maintenance
-      outputs:
-      - name: charts-maintenance
-      run:
-        dir: charts-maintenance
-        path: make
-        args: [pipeline.yml]
   - put: prod
     params:
       pipelines:
@@ -164,15 +135,37 @@ jobs:
       - name: prs
         team: main
         config_file: pipelines/pipelines/prs.yml
+      - name: helm-prs
+        team: main
+        conifg_file: pipelines/pipelines/helm-prs.yml
+        vars:
+          pr_base_branch: master
+          # Why a release branch and not master?
+          # A: We want to test pr's against the last stable release of Concourse,
+          # in particular we care about which version of k8s-topgun we use.
+          # Dev flags are tested in the main pipeline with other unreleased code
+          concourse_base_branch: release/5.7.x
+          concourse_image_tag: latest
+      - name: helm-prs-5.5.x
+        team: main
+        conifg_file: pipelines/pipelines/helm-prs.yml
+        vars:
+          pr_base_branch: release/5.5.x
+          concourse_base_branch: release/5.5.x
+          concourse_image_tag: 5.5
+      - name: helm-prs-5.7.x
+        team: main
+        conifg_file: pipelines/pipelines/helm-prs.yml
+        vars:
+          pr_base_branch: release/5.7.x
+          concourse_base_branch: release/5.7.x
+          concourse_image_tag: 5.7
       - name: bosh-cleanup
         team: main
         config_file: pipelines/pipelines/bosh-cleanup.yml
       - name: wings
         team: main
         config_file: pipelines/pipelines/wings.yml
-      - name: concourse-charts
-        team: main
-        config_file: charts-maintenance/pipeline.yml
       - name: norsk-mirror
         team: main
         config_file: pipelines/pipelines/norsk-mirror.yml


### PR DESCRIPTION
Addresses part of https://github.com/pivotal/concourse-ops/issues/150

There are now multiple helm-pr pipelines:

- `helm-prs` is for testing commits against master. It tests the latest
stable concourse/concourse image with the k8s-topgun it was released
with
- `helm-prs-x.x.x` pipelines for when we need to backport patches.
These allow for fast feedback.

We also tried running a smaller subset of the k8s-topgun suite that
covered a majority of user-facing features. We chose the "Worker
Lifecycle" tests which are 2/43 of all tests. These tests alone take
9-10mins to run vs 18-20mins for the entire suite. For now we'll run the
entire test suite. In the future we could create a "smoke" test suite
that runs faster (2-3mins?) potentially and use that for testing PR's
intead.

Necessary secrets have been saved into vault at the team level since they'll be shared by multiple `helm-pr` pipelines.

These pipelines will not work until https://github.com/concourse/ci/issues/192 is done.

cc @taylorsilva 