### PR TITLE
Revert "add parameterized ignored-in-concourse extras"

### DIFF
--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -170,7 +170,6 @@ jobs:
           release_minor: "5.2"
           concourse_smoke_deployment_name: "concourse-smoke-5-2"
           use_external_linker: true
-          ignored_in_concourse: CONCOURSE_MAIN_TEAM_CONFIG
       - name: release-5.5.x
         team: main
         exposed: true
@@ -180,7 +179,6 @@ jobs:
           release_minor: "5.5"
           concourse_smoke_deployment_name: "concourse-smoke-5-5"
           use_external_linker: false
-          ignored_in_concourse: CONCOURSE_MAIN_TEAM_CONFIG
       - name: release-5.7.x
         team: main
         exposed: true
@@ -190,7 +188,6 @@ jobs:
           release_minor: "5.7"
           concourse_smoke_deployment_name: "concourse-smoke-5-7"
           use_external_linker: false
-          ignored_in_concourse: CONCOURSE_MAIN_TEAM_CONFIG
       - name: algorithm-v3
         team: main
         config_file: pipelines/pipelines/branch.yml

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -6,10 +6,6 @@
 #   ((concourse_smoke_deployment_name)) a unique name for the smoke bosh deployment
 #   ((use_external_linker))             whether to use an external linker for go builds;
 #                                       otherwise the built-in go linker will be used.
-#   ((ignored_in_concourse))            multiline string containing CONCOURSE_* env vars
-#                                       that the Concourse binary cares about but
-#                                       are not needed in the helm/bosh packaging
-#                                       for this release.
 #
 # the following git branches need to be created:
 #
@@ -381,7 +377,7 @@ jobs:
     file: ci/tasks/check-distribution-env.yml
     image: unit-image
     input_mapping: {distribution: concourse-chart, linux-rc: linux-rc-ubuntu}
-    params: {DISTRIBUTION: helm, IGNORED_IN_CONCOURSE: ((ignored_in_concourse))}
+    params: {DISTRIBUTION: helm}
   on_success: *fixed-concourse
   on_failure: *broke-concourse
 
@@ -677,7 +673,7 @@ jobs:
     file: ci/tasks/check-distribution-env.yml
     image: unit-image
     input_mapping: {distribution: concourse-release-repo, linux-rc: linux-rc-ubuntu}
-    params: {DISTRIBUTION: bosh, IGNORED_IN_CONCOURSE: ((ignored_in_concourse))}
+    params: {DISTRIBUTION: bosh}
 
 - name: bosh-bump
   public: true

--- a/tasks/check-distribution-env.yml
+++ b/tasks/check-distribution-env.yml
@@ -14,7 +14,6 @@ inputs:
 params:
   # distribution to check (one of 'helm' or 'bosh')
   DISTRIBUTION: ''
-  IGNORED_IN_CONCOURSE: ''
 
 run:
   path: ci/tasks/scripts/check-distribution-env/diff

--- a/tasks/scripts/check-distribution-env/diff
+++ b/tasks/scripts/check-distribution-env/diff
@@ -44,7 +44,7 @@ main() {
 }
 
 get_distribution_variables() {
-  $distro_scripts/list-actual $distro_dir | filter_list $distro_scripts/ignored-in-distribution
+  $distro_scripts/list-actual $distro_dir | filter_list ignored-in-distribution
 }
 
 get_concourse_variables() {
@@ -54,11 +54,11 @@ get_concourse_variables() {
     $linux_rc/concourse/bin/concourse $subcommand --help 2>&1 |
       grep -o '\[\$.*\]' |
       tr -d \[\]\$
-  done | filter_list <(echo "$IGNORED_IN_CONCOURSE"; cat $distro_scripts/ignored-in-concourse)
+  done | filter_list ignored-in-concourse
 }
 
 filter_list() {
-  local filter="$(cat $1 | xargs | tr ' ' '|')"
+  local filter="$(cat $distro_scripts/$1 | xargs | tr ' ' '|')"
 
   if [ -z "$filter" ]; then
     tee


### PR DESCRIPTION
this ended up not being enough; if one distribution supports the param
but not another, the distribution that supports it will fail.

instead let's just try to be consistent with supported/ignored configs
across releases, backporting params to patch releases when necessary.

This reverts commit b2eb637eadc572d35216edad30d042eadffb7a3e.
