### PR TITLE
Add deploy step for bosh-topgun worker

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -1104,6 +1104,28 @@ jobs:
     - get: bbr-sdk-release
     - get: prod
     - get: ci
+  - put: bosh-topgun-worker-deployment
+    tags: [topgun]
+    params:
+      manifest: cbd/cluster/external-worker.yml
+      stemcells:
+      - gcp-xenial-stemcell/*.tgz
+      releases:
+      - concourse-release/*.tgz
+      - bpm-release/*.tgz
+      ops_files:
+      vars_files:
+      - cbd/versions.yml
+      vars:
+        deployment_name: topgun-worker
+        instances: 1
+        azs: [z1]
+        worker_vm_type: worker
+        external_worker_network_name: default
+        worker_tags: [topgun]
+        tsa_host: "nci.concourse-ci.org"
+        tsa_host_key.public_key: ((tsa_host_public_key))
+        worker_key: ((worker_private_key))
   - put: prod-deployment
     params:
       manifest: cbd/cluster/concourse.yml
@@ -1837,6 +1859,17 @@ resources:
     client: ((bosh_client.id))
     client_secret: ((bosh_client.secret))
     deployment: concourse-prod
+
+- name: bosh-topgun-worker-deployment
+  tags: [topgun]
+  type: bosh-deployment
+  icon: sync
+  source:
+    target: https://10.0.0.6:25555
+    client: ((topgun_bosh_client.id))
+    client_secret: ((topgun_bosh_client.secret))
+    ca_cert: ((topgun_ca_cert))
+    deployment: topgun-worker
 
 - name: gcp-xenial-stemcell
   type: bosh-io-stemcell

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -1114,8 +1114,7 @@ jobs:
       - concourse-release/*.tgz
       - bpm-release/*.tgz
       ops_files:
-      vars_files:
-      - cbd/versions.yml
+      - cbd/cluster/operations/dev-versions.yml
       vars:
         deployment_name: topgun-worker
         instances: 1


### PR DESCRIPTION
fixes https://github.com/concourse/prod/issues/43

This PR adds a `put` step to redeploy our bosh topgun worker.

This `put` step, added to when we redeploy ci, ensures that our bosh
external worker is updated at the same time. Had to add `worker_private_key` and `tsa_host_public_key`, at the pipeline level in vault (`concourse/main/concourse/`)