### PR TITLE
Switch concourse-chart resource to master branch

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -1877,7 +1877,7 @@ resources:
   icon: *git-icon
   source:
     uri: https://github.com/concourse/concourse-chart.git
-    branch: dev
+    branch: master
 
 - name: helm-charts
   type: git


### PR DESCRIPTION
We decided to stick with the dev workflow that the rest of the team
follows instead of going with a `dev` and `stable` branches workflow.
Figured it's better to keep the dev experience consistent within the
team, less overhead when people have to work with this repo (concourse-chart).