### PR TITLE
use instance_url for quickstart tests

### DIFF
--- a/tasks/scripts/quickstart-smoke
+++ b/tasks/scripts/quickstart-smoke
@@ -16,7 +16,7 @@ popd
 # now run the watjs/smoke tests
 mkdir -p endpoint-info
 pushd endpoint-info
-  echo "localhost" > instance_ip
+  echo "http://localhost:8080" > instance_url
   echo "test" > admin_username
   echo "test" > admin_password
 popd


### PR DESCRIPTION
during concourse/ci#240 we missed updating the quickstart tests, so now we see failures like:
https://nci.concourse-ci.org/teams/main/pipelines/concourse/jobs/quickstart-smoke/builds/17#L5de94397:236

This PR should fix that.