### PR TITLE
DNS name for bin-smoke

### DIFF
--- a/deployments/smoke/smoke.tf
+++ b/deployments/smoke/smoke.tf
@@ -109,7 +109,7 @@ data "template_file" "web_conf" {
   template = file("systemd/smoke-web.conf.tpl")
 
   vars = {
-    instance_url   = "https://${google_compute_address.smoke.address}"
+    instance_url   = "https://${google_compute_address.smoke.address}.xip.io"
     admin_password = random_string.admin_password.result
     guest_password = random_string.guest_password.result
   }
@@ -189,7 +189,7 @@ resource "null_resource" "rerun" {
 }
 
 output "instance_url" {
-  value = "https://${google_compute_address.smoke.address}"
+  value = "https://${google_compute_address.smoke.address}.xip.io"
 }
 
 output "admin_password" {

--- a/dockerfiles/unit/Dockerfile
+++ b/dockerfiles/unit/Dockerfile
@@ -66,4 +66,15 @@ RUN curl -L https://releases.hashicorp.com/vault/0.7.3/vault_0.7.3_linux_amd64.z
 RUN curl -fsSL https://releases.hashicorp.com/terraform/0.12.6/terraform_0.12.6_linux_amd64.zip -o /tmp/terraform.zip && \
       unzip /tmp/terraform.zip -d /usr/local/bin && \
       rm /tmp/terraform.zip
-RUN apt-get update && apt-get -y install jq openssh-client
+RUN apt-get update && apt-get -y install jq openssh-client libnss3-tools
+RUN curl -so /etc/ssl/certs/fake_root.pem \
+  https://letsencrypt.org/certs/fakelerootx1.pem && \
+  chmod 644 /etc/ssl/certs/fake_root.pem && \
+  mkdir -p /root/.pki/nssdb && \
+  chmod 700 /root/.pki/nssdb && \
+  certutil -N -d sql:/root/.pki/nssdb --empty-password && \
+  certutil -A \
+    -n "LetsEncrypt Staging Fake Root" \
+    -t "TCu,Cu,Tu" \
+    -i /etc/ssl/certs/fake_root.pem \
+    -d sql:/root/.pki/nssdb


### PR DESCRIPTION
Fixes concourse/ci#244

Also install LetsEncrypt's fake root used to sign certs from the staging environment. We ended up needing to install this in /etc/ssl/certs for curl, and add it to the nssdb for chromium.