### PR TITLE
Rename references to the testing bosh director

### DIFF
--- a/pipelines/branch.yml
+++ b/pipelines/branch.yml
@@ -552,9 +552,9 @@ jobs:
     image: unit-image
     params:
       BOSH_ENVIRONMENT: https://10.0.0.6:25555
-      BOSH_CA_CERT: ((topgun_ca_cert))
-      BOSH_CLIENT: ((topgun_bosh_client.id))
-      BOSH_CLIENT_SECRET: ((topgun_bosh_client.secret))
+      BOSH_CA_CERT: ((testing_bosh_ca_cert))
+      BOSH_CLIENT: ((testing_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((testing_bosh_client.secret))
       BOSH_DEPLOYMENT: concourse-smoke-((branch_name))
       BOSH_INSTANCE_GROUP: concourse
   - task: smoke
@@ -604,9 +604,9 @@ jobs:
     params:
       DEPLOYMENT_NAME_PREFIX: concourse-topgun-((branch_name))
       BOSH_ENVIRONMENT: https://10.0.0.6:25555
-      BOSH_CA_CERT: ((topgun_ca_cert))
-      BOSH_CLIENT: ((topgun_bosh_client.id))
-      BOSH_CLIENT_SECRET: ((topgun_bosh_client.secret))
+      BOSH_CA_CERT: ((testing_bosh_ca_cert))
+      BOSH_CLIENT: ((testing_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((testing_bosh_client.secret))
       BOSH_SSH_KEY: ((topgun_bosh_key))
       AWS_REGION: ((topgun_aws_ssm.region))
       AWS_ACCESS_KEY_ID: ((topgun_aws_ssm.access_key_id))
@@ -783,9 +783,9 @@ resources:
   icon: fire
   source:
     target: https://10.0.0.6:25555
-    client: ((topgun_bosh_client.id))
-    client_secret: ((topgun_bosh_client.secret))
-    ca_cert: ((topgun_ca_cert))
+    client: ((testing_bosh_client.id))
+    client_secret: ((testing_bosh_client.secret))
+    ca_cert: ((testing_bosh_ca_cert))
     deployment: concourse-smoke-((branch_name))
 
 - name: concourse-chart
@@ -1027,9 +1027,9 @@ resources:
   icon: sync
   source:
     target: https://10.0.0.6:25555
-    client: ((topgun_bosh_client.id))
-    client_secret: ((topgun_bosh_client.secret))
-    ca_cert: ((topgun_ca_cert))
+    client: ((testing_bosh_client.id))
+    client_secret: ((testing_bosh_client.secret))
+    ca_cert: ((testing_bosh_ca_cert))
     deployment: concourse-((environment))
 
 - name: resource-types-image

--- a/pipelines/branch.yml
+++ b/pipelines/branch.yml
@@ -535,7 +535,7 @@ jobs:
       trigger: true
     - get: ci
   - put: smoke-deployment
-    tags: [topgun]
+    tags: [bosh]
     params:
       manifest: ci/deployments/bosh-smoke.yml
       releases:
@@ -547,7 +547,7 @@ jobs:
       vars:
         deployment_name: concourse-smoke-((branch_name))
   - task: discover-bosh-endpoint-info
-    tags: [topgun]
+    tags: [bosh]
     file: ci/tasks/discover-bosh-endpoint-info.yml
     image: unit-image
     params:
@@ -559,7 +559,7 @@ jobs:
       BOSH_INSTANCE_GROUP: concourse
   - task: smoke
     # Ensure the task runs on a BOSH deployed worker so it can reach the deployment
-    tags: [topgun]
+    tags: [bosh]
     image: unit-image
     file: ci/tasks/smoke.yml
 
@@ -595,7 +595,7 @@ jobs:
     - get: ci
   - task: bosh-topgun
     # Ensure the task runs on a BOSH deployed worker so it can reach the deployment
-    tags: [topgun]
+    tags: [bosh]
     file: ci/tasks/topgun.yml
     image: unit-image
     input_mapping:

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -868,9 +868,9 @@ jobs:
     image: unit-image
     params:
       BOSH_ENVIRONMENT: https://10.0.0.6:25555
-      BOSH_CA_CERT: ((topgun_ca_cert))
-      BOSH_CLIENT: ((topgun_bosh_client.id))
-      BOSH_CLIENT_SECRET: ((topgun_bosh_client.secret))
+      BOSH_CA_CERT: ((testing_bosh_ca_cert))
+      BOSH_CLIENT: ((testing_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((testing_bosh_client.secret))
       BOSH_DEPLOYMENT: concourse-smoke
       BOSH_INSTANCE_GROUP: concourse
   - task: smoke
@@ -919,9 +919,9 @@ jobs:
       stemcell: gcp-xenial-stemcell
     params:
       BOSH_ENVIRONMENT: https://10.0.0.6:25555
-      BOSH_CA_CERT: ((topgun_ca_cert))
-      BOSH_CLIENT: ((topgun_bosh_client.id))
-      BOSH_CLIENT_SECRET: ((topgun_bosh_client.secret))
+      BOSH_CA_CERT: ((testing_bosh_ca_cert))
+      BOSH_CLIENT: ((testing_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((testing_bosh_client.secret))
       AWS_REGION: ((topgun_aws_ssm.region))
       AWS_ACCESS_KEY_ID: ((topgun_aws_ssm.access_key_id))
       AWS_SECRET_ACCESS_KEY: ((topgun_aws_ssm.secret_access_key))
@@ -968,9 +968,9 @@ jobs:
       stemcell: gcp-xenial-stemcell
     params:
       BOSH_ENVIRONMENT: https://10.0.0.6:25555
-      BOSH_CA_CERT: ((topgun_ca_cert))
-      BOSH_CLIENT: ((topgun_bosh_client.id))
-      BOSH_CLIENT_SECRET: ((topgun_bosh_client.secret))
+      BOSH_CA_CERT: ((testing_bosh_ca_cert))
+      BOSH_CLIENT: ((testing_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((testing_bosh_client.secret))
       AWS_REGION: ((topgun_aws_ssm.region))
       AWS_ACCESS_KEY_ID: ((topgun_aws_ssm.access_key_id))
       AWS_SECRET_ACCESS_KEY: ((topgun_aws_ssm.secret_access_key))
@@ -1017,9 +1017,9 @@ jobs:
       stemcell: gcp-xenial-stemcell
     params:
       BOSH_ENVIRONMENT: https://10.0.0.6:25555
-      BOSH_CA_CERT: ((topgun_ca_cert))
-      BOSH_CLIENT: ((topgun_bosh_client.id))
-      BOSH_CLIENT_SECRET: ((topgun_bosh_client.secret))
+      BOSH_CA_CERT: ((testing_bosh_ca_cert))
+      BOSH_CLIENT: ((testing_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((testing_bosh_client.secret))
       AWS_REGION: ((topgun_aws_ssm.region))
       AWS_ACCESS_KEY_ID: ((topgun_aws_ssm.access_key_id))
       AWS_SECRET_ACCESS_KEY: ((topgun_aws_ssm.secret_access_key))
@@ -1066,9 +1066,9 @@ jobs:
       stemcell: gcp-xenial-stemcell
     params:
       BOSH_ENVIRONMENT: https://10.0.0.6:25555
-      BOSH_CA_CERT: ((topgun_ca_cert))
-      BOSH_CLIENT: ((topgun_bosh_client.id))
-      BOSH_CLIENT_SECRET: ((topgun_bosh_client.secret))
+      BOSH_CA_CERT: ((testing_bosh_ca_cert))
+      BOSH_CLIENT: ((testing_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((testing_bosh_client.secret))
       AWS_REGION: ((topgun_aws_ssm.region))
       AWS_ACCESS_KEY_ID: ((topgun_aws_ssm.access_key_id))
       AWS_SECRET_ACCESS_KEY: ((topgun_aws_ssm.secret_access_key))
@@ -1780,9 +1780,9 @@ resources:
   icon: fire
   source:
     target: https://10.0.0.6:25555
-    client: ((topgun_bosh_client.id))
-    client_secret: ((topgun_bosh_client.secret))
-    ca_cert: ((topgun_ca_cert))
+    client: ((testing_bosh_client.id))
+    client_secret: ((testing_bosh_client.secret))
+    ca_cert: ((testing_bosh_ca_cert))
     deployment: concourse-smoke
 
 - name: gcp-xenial-stemcell

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -863,6 +863,7 @@ jobs:
       vars:
         deployment_name: concourse-smoke
   - task: discover-bosh-endpoint-info
+    tags: [bosh]
     file: ci/tasks/discover-bosh-endpoint-info.yml
     image: unit-image
     params:
@@ -872,6 +873,7 @@ jobs:
       BOSH_DEPLOYMENT: concourse-smoke
       BOSH_INSTANCE_GROUP: concourse
   - task: smoke
+    tags: [bosh]
     image: unit-image
     file: ci/tasks/smoke.yml
   on_success: *fixed-concourse
@@ -909,7 +911,7 @@ jobs:
       trigger: true
     - get: ci
   - task: bosh-topgun
-    tags: [topgun]
+    tags: [bosh]
     file: ci/tasks/topgun.yml
     image: unit-image
     input_mapping:
@@ -958,7 +960,7 @@ jobs:
       trigger: true
     - get: ci
   - task: bosh-topgun
-    tags: [topgun]
+    tags: [bosh]
     file: ci/tasks/topgun.yml
     image: unit-image
     input_mapping:
@@ -1007,7 +1009,7 @@ jobs:
       trigger: true
     - get: ci
   - task: bosh-topgun
-    tags: [topgun]
+    tags: [bosh]
     file: ci/tasks/topgun.yml
     image: unit-image
     input_mapping:
@@ -1056,7 +1058,7 @@ jobs:
       trigger: true
     - get: ci
   - task: bosh-topgun
-    tags: [topgun]
+    tags: [bosh]
     file: ci/tasks/topgun.yml
     image: unit-image
     input_mapping:

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -867,9 +867,10 @@ jobs:
     file: ci/tasks/discover-bosh-endpoint-info.yml
     image: unit-image
     params:
-      BOSH_ENVIRONMENT: ((bosh_target))
-      BOSH_CLIENT: ((bosh_client.id))
-      BOSH_CLIENT_SECRET: ((bosh_client.secret))
+      BOSH_ENVIRONMENT: https://10.0.0.6:25555
+      BOSH_CA_CERT: ((topgun_ca_cert))
+      BOSH_CLIENT: ((topgun_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((topgun_bosh_client.secret))
       BOSH_DEPLOYMENT: concourse-smoke
       BOSH_INSTANCE_GROUP: concourse
   - task: smoke
@@ -1774,13 +1775,14 @@ resources:
     private_key: ((concourse_release_deploy_key))
 
 - name: smoke-deployment
-  tags: [topgun]
+  tags: [bosh]
   type: bosh-deployment
   icon: fire
   source:
-    target: ((bosh_target))
-    client: ((bosh_client.id))
-    client_secret: ((bosh_client.secret))
+    target: https://10.0.0.6:25555
+    client: ((topgun_bosh_client.id))
+    client_secret: ((topgun_bosh_client.secret))
+    ca_cert: ((topgun_ca_cert))
     deployment: concourse-smoke
 
 - name: gcp-xenial-stemcell

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -757,9 +757,9 @@ jobs:
     image: unit-image
     params:
       BOSH_ENVIRONMENT: https://10.0.0.6:25555
-      BOSH_CA_CERT: ((topgun_ca_cert))
-      BOSH_CLIENT: ((topgun_bosh_client.id))
-      BOSH_CLIENT_SECRET: ((topgun_bosh_client.secret))
+      BOSH_CA_CERT: ((testing_bosh_ca_cert))
+      BOSH_CLIENT: ((testing_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((testing_bosh_client.secret))
       BOSH_DEPLOYMENT: ((concourse_smoke_deployment_name))
       BOSH_INSTANCE_GROUP: concourse
   - task: smoke
@@ -810,9 +810,9 @@ jobs:
     params:
       DEPLOYMENT_NAME_PREFIX: concourse-topgun-((release_minor))
       BOSH_ENVIRONMENT: https://10.0.0.6:25555
-      BOSH_CA_CERT: ((topgun_ca_cert))
-      BOSH_CLIENT: ((topgun_bosh_client.id))
-      BOSH_CLIENT_SECRET: ((topgun_bosh_client.secret))
+      BOSH_CA_CERT: ((testing_bosh_ca_cert))
+      BOSH_CLIENT: ((testing_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((testing_bosh_client.secret))
       AWS_REGION: ((topgun_aws_ssm.region))
       AWS_ACCESS_KEY_ID: ((topgun_aws_ssm.access_key_id))
       AWS_SECRET_ACCESS_KEY: ((topgun_aws_ssm.secret_access_key))
@@ -1285,9 +1285,9 @@ resources:
   icon: fire
   source:
     target: https://10.0.0.6:25555
-    client: ((topgun_bosh_client.id))
-    client_secret: ((topgun_bosh_client.secret))
-    ca_cert: ((topgun_ca_cert))
+    client: ((testing_bosh_client.id))
+    client_secret: ((testing_bosh_client.secret))
+    ca_cert: ((testing_bosh_ca_cert))
     deployment: ((concourse_smoke_deployment_name))
 
 - name: concourse-chart

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -740,7 +740,7 @@ jobs:
       trigger: true
     - get: ci
   - put: smoke-deployment
-    tags: [topgun]
+    tags: [bosh]
     params:
       manifest: ci/deployments/bosh-smoke.yml
       releases:
@@ -752,7 +752,7 @@ jobs:
       vars:
         deployment_name: ((concourse_smoke_deployment_name))
   - task: discover-bosh-endpoint-info
-    tags: [topgun]
+    tags: [bosh]
     file: ci/tasks/discover-bosh-endpoint-info.yml
     image: unit-image
     params:
@@ -763,7 +763,7 @@ jobs:
       BOSH_DEPLOYMENT: ((concourse_smoke_deployment_name))
       BOSH_INSTANCE_GROUP: concourse
   - task: smoke
-    tags: [topgun]
+    tags: [bosh]
     image: unit-image
     file: ci/tasks/smoke.yml
   on_success: *fixed-concourse
@@ -1280,7 +1280,7 @@ resources:
     private_key: ((concourse_release_deploy_key))
 
 - name: smoke-deployment
-  tags: [topgun]
+  tags: [bosh]
   type: bosh-deployment
   icon: fire
   source:

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -802,7 +802,7 @@ jobs:
       trigger: true
     - get: ci
   - task: bosh-topgun
-    tags: [topgun]
+    tags: [bosh]
     file: ci/tasks/topgun.yml
     image: unit-image
     input_mapping:


### PR DESCRIPTION
Fixes: pivotal/concourse-ops#176

We noticed that the `topgun` worker tags would be used on both `smoke` and `topgun` test, so it's better to rename it as `bosh`. Also moved the vault secrets for the testing bosh director.
```
topgun_ca_cert
topgun_bosh_client
```
to 
```
testing_bosh_ca_cert
testing_bosh_client
```

The `bosh-smoke` job in the main pipeline now uses the testing bosh director instead of the prod director. 
