### PR TITLE
pipelines/concourse: add containerd-integration

### DIFF
--- a/deployments/containerd/containerd.toml
+++ b/deployments/containerd/containerd.toml
@@ -1,0 +1,15 @@
+disabled_plugins = ["cri", "aufs", "btrfs", "zfs"]
+root = "/scratch/containerd"
+state = "/run/containerd"
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+
+[debug]
+  address = "/run/containerd/debug.sock"
+  level = "debug"
+
+[plugins]
+  [plugins."io.containerd.runtime.v1.linux"]
+    runtime = "runc"
+    shim = "containerd-shim"

--- a/dockerfiles/unit/Dockerfile
+++ b/dockerfiles/unit/Dockerfile
@@ -78,3 +78,19 @@ RUN curl -so /etc/ssl/certs/fake_root.pem \
     -t "TCu,Cu,Tu" \
     -i /etc/ssl/certs/fake_root.pem \
     -d sql:/root/.pki/nssdb
+
+# install containerd
+ARG RUNC_VERSION=v1.0.0-rc8
+ARG CNI_VERSION=v0.8.2
+ARG CONTAINERD_VERSION=1.3.0
+
+ENV PATH=$PATH:/usr/local/concourse/bin
+
+RUN set -x && \
+	mkdir -p /usr/local/concourse/bin && \
+	curl -sSL https://github.com/containerd/containerd/releases/download/v$CONTAINERD_VERSION/containerd-$CONTAINERD_VERSION.linux-amd64.tar.gz \
+		| tar -zvxf - -C /usr/local/concourse/bin --strip-components=1 && \
+	curl -sSL https://github.com/opencontainers/runc/releases/download/$RUNC_VERSION/runc.amd64 \
+		-o /usr/local/concourse/bin/runc && chmod +x /usr/local/concourse/bin/runc && \
+	curl -sSL https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION/cni-plugins-linux-amd64-$CNI_VERSION.tgz \
+		| tar -zvxf - -C /usr/local/concourse/bin

--- a/dockerfiles/unit/Dockerfile
+++ b/dockerfiles/unit/Dockerfile
@@ -85,8 +85,6 @@ ARG CNI_VERSION=v0.8.3
 ARG CONTAINERD_VERSION=1.3.2
 ARG INIT_VERSION=1.2.2
 
-ENV PATH=$PATH:/usr/local/concourse/bin
-
 RUN set -x && \
 	mkdir -p /usr/local/concourse/bin && \
 	curl -sSL https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \

--- a/dockerfiles/unit/Dockerfile
+++ b/dockerfiles/unit/Dockerfile
@@ -89,6 +89,8 @@ ENV PATH=$PATH:/usr/local/concourse/bin
 
 RUN set -x && \
 	mkdir -p /usr/local/concourse/bin && \
+	curl -sSL https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
+		-o /usr/local/concourse/bin/init && chmod +x /usr/local/concourse/bin/init && \
 	curl -sSL https://github.com/containerd/containerd/releases/download/v$CONTAINERD_VERSION/containerd-$CONTAINERD_VERSION.linux-amd64.tar.gz \
 		| tar -zvxf - -C /usr/local/concourse/bin --strip-components=1 && \
 	curl -sSL https://github.com/opencontainers/runc/releases/download/$RUNC_VERSION/runc.amd64 \

--- a/dockerfiles/unit/Dockerfile
+++ b/dockerfiles/unit/Dockerfile
@@ -80,9 +80,10 @@ RUN curl -so /etc/ssl/certs/fake_root.pem \
     -d sql:/root/.pki/nssdb
 
 # install containerd
-ARG RUNC_VERSION=v1.0.0-rc8
-ARG CNI_VERSION=v0.8.2
-ARG CONTAINERD_VERSION=1.3.0
+ARG RUNC_VERSION=v1.0.0-rc9
+ARG CNI_VERSION=v0.8.3
+ARG CONTAINERD_VERSION=1.3.2
+ARG INIT_VERSION=1.2.2
 
 ENV PATH=$PATH:/usr/local/concourse/bin
 

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -308,7 +308,7 @@ jobs:
 
 - name: containerd-integration
   public: true
-  max_in_flight: 2
+  max_in_flight: 1
   plan:
   - in_parallel:
     - get: concourse

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -21,6 +21,7 @@ groups:
   - unit
   - dev-image
   - testflight
+  - containerd-integration
   - watsjs
   - rc
   - build-rc
@@ -302,6 +303,24 @@ jobs:
   - put: dev-image
     params: {image: image/image.tar}
     get_params: {format: oci}
+  on_success: *fixed-concourse
+  on_failure: *broke-concourse
+
+- name: containerd-integration
+  public: true
+  max_in_flight: 2
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [unit]
+      trigger: true
+    - get: unit-image
+    - get: ci
+  - task: integration
+    image: unit-image
+    privileged: true
+    timeout: 1h
+    file: ci/tasks/containerd-integration.yml
   on_success: *fixed-concourse
   on_failure: *broke-concourse
 

--- a/tasks/containerd-integration.yml
+++ b/tasks/containerd-integration.yml
@@ -1,0 +1,18 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/unit}
+
+inputs:
+- name: concourse
+- name: ci
+
+caches:
+- path: gopath
+
+run:
+  path: ci/tasks/scripts/pass-release-notes-only-change
+  args:
+  - ci/tasks/scripts/containerd-integration

--- a/tasks/scripts/cgroup-helpers.sh
+++ b/tasks/scripts/cgroup-helpers.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e -u
+
+function sanitize_cgroups() {
+  mkdir -p /sys/fs/cgroup
+  mountpoint -q /sys/fs/cgroup || \
+    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+
+  mount -o remount,rw /sys/fs/cgroup
+
+  sed -e 1d /proc/cgroups | while read sys hierarchy num enabled; do
+    if [ "$enabled" != "1" ]; then
+      # subsystem disabled; skip
+      continue
+    fi
+
+    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")"
+    if [ -z "$grouping" ]; then
+      # subsystem not mounted anywhere; mount it on its own
+      grouping="$sys"
+    fi
+
+    mountpoint="/sys/fs/cgroup/$grouping"
+
+    mkdir -p "$mountpoint"
+
+    # clear out existing mount to make sure new one is read-write
+    if mountpoint -q "$mountpoint"; then
+      umount "$mountpoint"
+    fi
+
+    mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
+
+    if [ "$grouping" != "$sys" ]; then
+      if [ -L "/sys/fs/cgroup/$sys" ]; then
+        rm "/sys/fs/cgroup/$sys"
+      fi
+
+      ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
+    fi
+  done
+
+  if ! test -e /sys/fs/cgroup/systemd ; then
+    mkdir /sys/fs/cgroup/systemd
+    mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
+  fi
+}
+

--- a/tasks/scripts/cgroup-helpers.sh
+++ b/tasks/scripts/cgroup-helpers.sh
@@ -2,19 +2,43 @@
 
 set -e -u
 
+# ensure that we have the all of the enabled cgroup controllers mounted under
+# `/sys/fs/cgroup` read-write.
+#
 function sanitize_cgroups() {
   mkdir -p /sys/fs/cgroup
+
+  # check if the `/sys/fs/cgroup` directory is a mountpoint or not.
+  #
+  # inside garden privileged containers, this evaluate to `false` by default,
+  # thus, we need to go ahead and mount the` cgroup` filesystem here.
+  #
+  # remembering the `mount(8)` syntax:
+  #
+  #     mount -t <type> -o <opts> <device> <mountpoint>
+  #
+  # so, we start by creating a `tmpfs` mount on `/sys/fs/cgroup` naming the
+  # "source device" as "cgroup" (it could be named anything as the "device"
+  # backing `tmpfs` is just memory).
+  #
   mountpoint -q /sys/fs/cgroup || \
     mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
 
+  # ensure that we have `/sys/fs/cgroup` as `read-write` so that we can mutate
+  # it (assuming in the case above, we got a positive for the mountpoint check)
+  #
   mount -o remount,rw /sys/fs/cgroup
 
+  # go over each of the controllers that are enabled in this kernel
+  #
   sed -e 1d /proc/cgroups | while read sys hierarchy num enabled; do
     if [ "$enabled" != "1" ]; then
       # subsystem disabled; skip
       continue
     fi
 
+    # it could be that the controller we're looking at is already mounted
+    # somewhere.
     grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")"
     if [ -z "$grouping" ]; then
       # subsystem not mounted anywhere; mount it on its own
@@ -26,12 +50,18 @@ function sanitize_cgroups() {
     mkdir -p "$mountpoint"
 
     # clear out existing mount to make sure new one is read-write
+    #
     if mountpoint -q "$mountpoint"; then
       umount "$mountpoint"
     fi
 
+    # mount the grouping under mountpoint (e.g., `/sys/fs/cgroup/pids`)
+    #
     mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
 
+    # ensure that each controller get its path (e.g., `cpu,cpuacct` --> `cpu` and
+    # `cpuacct` symlinks pointing to `cpu,cpuacct`).
+    #
     if [ "$grouping" != "$sys" ]; then
       if [ -L "/sys/fs/cgroup/$sys" ]; then
         rm "/sys/fs/cgroup/$sys"
@@ -41,9 +71,10 @@ function sanitize_cgroups() {
     fi
   done
 
+  # mount the named `systemd` cgroup hierarchy with no attached controllers
+  #
   if ! test -e /sys/fs/cgroup/systemd ; then
     mkdir /sys/fs/cgroup/systemd
     mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
   fi
 }
-

--- a/tasks/scripts/containerd-integration
+++ b/tasks/scripts/containerd-integration
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e -u -x
+set -e -u
 
 export GOPATH=$PWD/gopath
 export PATH=$GOPATH/bin:$PATH

--- a/tasks/scripts/containerd-integration
+++ b/tasks/scripts/containerd-integration
@@ -34,7 +34,7 @@ state = "/run/containerd"
     shim = "containerd-shim"
 ' >./containerd.toml
 
-  containerd --config ./containerd.toml >/tmp/containerd.log 2>&1 &
+  PATH=/usr/local/concourse/bin containerd --config ./containerd.toml >/tmp/containerd.log 2>&1 &
   echo $! >/tmp/containerd.pid
 
   sleep 1

--- a/tasks/scripts/containerd-integration
+++ b/tasks/scripts/containerd-integration
@@ -17,7 +17,7 @@ start_containerd() {
   mkdir -p /scratch/containerd
 
   echo '
-disabled_plugins = ["cri"]
+disabled_plugins = ["cri", "aufs", "btrfs", "zfs"]
 root = "/scratch/containerd"
 state = "/run/containerd"
 

--- a/tasks/scripts/containerd-integration
+++ b/tasks/scripts/containerd-integration
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e -u -x
+
+export GOPATH=$PWD/gopath
+export PATH=$GOPATH/bin:$PATH
+
+source ci/tasks/scripts/docker-helpers.sh
+
+main() {
+  sanitize_cgroups
+  start_containerd
+  run_test
+}
+
+start_containerd() {
+  containerd >/tmp/containerd.log 2>&1 &
+  echo $! >/tmp/containerd.pid
+
+  sleep 1
+
+  until ctr version >/dev/null 2>&1; do
+    echo "waiting for containerd to come up..."
+    sleep 1
+  done
+}
+
+run_test() {
+  cd concourse
+
+  go mod download
+  go install github.com/onsi/ginkgo/ginkgo
+
+  ginkgo -r -nodes=4 -race -keepGoing -slowSpecThreshold=15 ./worker/backend/integration "$@"
+}
+
+main "$@"

--- a/tasks/scripts/containerd-integration
+++ b/tasks/scripts/containerd-integration
@@ -5,7 +5,7 @@ set -e -u
 export GOPATH=$PWD/gopath
 export PATH=$GOPATH/bin:$PATH
 
-source ci/tasks/scripts/docker-helpers.sh
+source ci/tasks/scripts/cgroup-helpers.sh
 
 main() {
   sanitize_cgroups

--- a/tasks/scripts/containerd-integration
+++ b/tasks/scripts/containerd-integration
@@ -14,7 +14,27 @@ main() {
 }
 
 start_containerd() {
-  containerd >/tmp/containerd.log 2>&1 &
+  mkdir -p /scratch/containerd
+
+  echo '
+disabled_plugins = ["cri"]
+root = "/scratch/containerd"
+state = "/run/containerd"
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+
+[debug]
+  address = "/run/containerd/debug.sock"
+  level = "debug"
+
+[plugins]
+  [plugins."io.containerd.runtime.v1.linux"]
+    runtime = "runc"
+    shim = "containerd-shim"
+' >./containerd.toml
+
+  containerd --config ./containerd.toml >/tmp/containerd.log 2>&1 &
   echo $! >/tmp/containerd.pid
 
   sleep 1

--- a/tasks/scripts/containerd-integration
+++ b/tasks/scripts/containerd-integration
@@ -16,25 +16,7 @@ main() {
 start_containerd() {
   mkdir -p /scratch/containerd
 
-  echo '
-disabled_plugins = ["cri", "aufs", "btrfs", "zfs"]
-root = "/scratch/containerd"
-state = "/run/containerd"
-
-[grpc]
-  address = "/run/containerd/containerd.sock"
-
-[debug]
-  address = "/run/containerd/debug.sock"
-  level = "debug"
-
-[plugins]
-  [plugins."io.containerd.runtime.v1.linux"]
-    runtime = "runc"
-    shim = "containerd-shim"
-' >./containerd.toml
-
-  PATH=/usr/local/concourse/bin containerd --config ./containerd.toml >/tmp/containerd.log 2>&1 &
+  PATH=/usr/local/concourse/bin containerd --config ./ci/deployments/containerd.toml >/tmp/containerd.log 2>&1 &
   echo $! >/tmp/containerd.pid
 
   sleep 1

--- a/tasks/scripts/docker-helpers.sh
+++ b/tasks/scripts/docker-helpers.sh
@@ -2,50 +2,7 @@
 
 set -e -u
 
-function sanitize_cgroups() {
-  mkdir -p /sys/fs/cgroup
-  mountpoint -q /sys/fs/cgroup || \
-    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
-
-  mount -o remount,rw /sys/fs/cgroup
-
-  sed -e 1d /proc/cgroups | while read sys hierarchy num enabled; do
-    if [ "$enabled" != "1" ]; then
-      # subsystem disabled; skip
-      continue
-    fi
-
-    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")"
-    if [ -z "$grouping" ]; then
-      # subsystem not mounted anywhere; mount it on its own
-      grouping="$sys"
-    fi
-
-    mountpoint="/sys/fs/cgroup/$grouping"
-
-    mkdir -p "$mountpoint"
-
-    # clear out existing mount to make sure new one is read-write
-    if mountpoint -q "$mountpoint"; then
-      umount "$mountpoint"
-    fi
-
-    mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
-
-    if [ "$grouping" != "$sys" ]; then
-      if [ -L "/sys/fs/cgroup/$sys" ]; then
-        rm "/sys/fs/cgroup/$sys"
-      fi
-
-      ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
-    fi
-  done
-
-  if ! test -e /sys/fs/cgroup/systemd ; then
-    mkdir /sys/fs/cgroup/systemd
-    mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
-  fi
-}
+source ci/tasks/scripts/cgroup-helpers.sh
 
 function start_docker() {
   mkdir -p /var/log


### PR DESCRIPTION
As the `containerd` backend integration tests require `containerd` to be
running, we need to have its binaries present in the image that forms
the base that runs such tests.

Given that `unit` has been the place where all extra dependencies get
added, there's where `containerd` end up being added to.

For the execution of the tests, a separate job was created so that we
don't get possible failures from `testflight` when the problem is
isolated to `containerd` only.


---

This is building upon https://github.com/concourse/ci/pull/246#issuecomment-571782505, where
I proposed to go with a separate job for the containerd integration, while
keeping `containerd` (the binary) itself in `unit`.

<img width="698" alt="Screen Shot 2020-01-08 at 9 26 59 AM" src="https://user-images.githubusercontent.com/3574444/71986216-15781e00-31fa-11ea-95e7-46d79c02724f.png">


Wdyt @concourse/runtime ? 

thanks! 

---

marked as `wip` until I get a full run of it through `fly execute`