### PR TITLE
dockerfiles/unit: bump nodejs version

### DIFF
--- a/dockerfiles/unit/Dockerfile
+++ b/dockerfiles/unit/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get -y install postgresql-11
 ENV PATH $PATH:/usr/lib/postgresql/11/bin
 
 # install Node 8.x
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update && apt-get install -y nodejs
 
 # install Yarn for web UI tests

--- a/dockerfiles/unit/Dockerfile
+++ b/dockerfiles/unit/Dockerfile
@@ -17,7 +17,7 @@ RUN add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_relea
 RUN apt-get update && apt-get -y install postgresql-11
 ENV PATH $PATH:/usr/lib/postgresql/11/bin
 
-# install Node 8.x
+# install Node 12.x
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update && apt-get install -y nodejs
 


### PR DESCRIPTION
the version of nodejs that we're using just reached its maintenance end
of life.

despite v12 not being the very latest version of node, it's the latest
LTS, which  gives us maintenance up until 2022-04-30.

