### PR TITLE
Make the alpine image actually based on alpine

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -659,10 +659,14 @@ jobs:
       - task: concourse-linux-alpine
         file: ci/tasks/concourse-build-linux.yml
         image: unit-image
+        params:
+          PLATFORM: linux
         input_mapping: {concourse: built-concourse, resource-types: resource-types-alpine}
         output_mapping: {concourse-linux: concourse-linux-alpine}
       - task: concourse-linux-ubuntu
         image: unit-image
+        params:
+          PLATFORM: linux-ubuntu
         file: ci/tasks/concourse-build-linux.yml
         input_mapping: {concourse: built-concourse, resource-types: resource-types-ubuntu}
         output_mapping: {concourse-linux: concourse-linux-ubuntu}

--- a/tasks/concourse-build-linux.yml
+++ b/tasks/concourse-build-linux.yml
@@ -27,6 +27,8 @@ caches:
 outputs:
 - name: concourse-linux
 
+params:
+  PLATFORM: linux
+
 run:
   path: ci/tasks/scripts/concourse-build
-  args: [linux]

--- a/tasks/scripts/concourse-build
+++ b/tasks/scripts/concourse-build
@@ -7,7 +7,7 @@ export GOPATH=$PWD/gopath
 export PATH=$PWD/gopath/bin:$PATH
 
 if [ -z "${PLATFORM}" ]; then
-  echo "usage: export PLATFORM=<platform> $0" >&2
+  echo "usage: PLATFORM=<platform> $0" >&2
   exit 1
 fi
 

--- a/tasks/scripts/concourse-build
+++ b/tasks/scripts/concourse-build
@@ -6,15 +6,13 @@ set -e -x
 export GOPATH=$PWD/gopath
 export PATH=$PWD/gopath/bin:$PATH
 
-if [ "$#" -lt 1 ]; then
-  echo "usage: $0 <platform>" >&2
+if [ -z "${PLATFORM}" ]; then
+  echo "usage: export PLATFORM=<platform> $0" >&2
   exit 1
 fi
 
-platform="$1"
-
 sha="$(git -C concourse rev-parse HEAD)"
-archive=concourse-${sha}-${platform}-amd64.tgz
+archive=concourse-${sha}-${PLATFORM}-amd64.tgz
 
 final_version=""
 ldflags=""
@@ -32,7 +30,7 @@ pushd concourse
   fi
 popd
 
-output=concourse-${platform}
+output=concourse-${PLATFORM}
 
 mkdir $output/concourse
 


### PR DESCRIPTION
Fixes https://github.com/concourse/concourse/issues/4586

We use the same task to build the alpine and ubuntu linux-rc's. They
both output the same filename and upload to the same gcs bucket
location. Ubuntu always wins because it's larger and takes longer to
upload. Last write = winner.

![Screen Shot 2020-01-20 at 3 59 01 PM](https://user-images.githubusercontent.com/4583837/72758666-6f38fa80-3ba1-11ea-8c27-daf728895953.png)


This change ensures that the file names are different. Alpine based image
will continue to end with `-linux` and ubuntu one's should end in
`linux-ubuntu` now.

I feel confident that there are no further upstream mix-ups. I looked at the `build-rc-image` task and it still maps everything properly.

```yaml
- name: build-rc-image
  public: true
...
  - in_parallel:
      fail_fast: true
      steps:
        - task: build-alpine
          file: concourse-docker/ci/build-image.yml
          image: oci-build-task
          output_mapping: {image: image-alpine}
          privileged: true
        - task: build-ubuntu
          file: concourse-docker/ci/build-image.yml
          image: oci-build-task
          input_mapping: {linux-rc: linux-rc-ubuntu} #this PR ensures the task gets the correct rc now
          output_mapping: {image: image-ubuntu}
...
```