### PR TITLE
Updated cf-resource to use the location at cloudfoundry-community

### DIFF
--- a/pipelines/branch.yml
+++ b/pipelines/branch.yml
@@ -903,7 +903,7 @@ resources:
   type: github-release
   icon: *release-icon
   source:
-    owner: concourse
+    owner: cloudfoundry-community
     repository: cf-resource
     access_token: ((concourse_github_dummy.access_token))
 

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -1584,7 +1584,7 @@ resources:
   type: github-release
   icon: *release-icon
   source:
-    owner: concourse
+    owner: cloudfoundry-community
     repository: cf-resource
     access_token: ((concourse_github_dummy.access_token))
 

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -1413,7 +1413,7 @@ resources:
   type: github-release
   icon: *release-icon
   source:
-    owner: concourse
+    owner: cloudfoundry-community
     repository: cf-resource
     access_token: ((concourse_github_dummy.access_token))
 


### PR DESCRIPTION
The old link `https://github.com/concourse/cf-resource` is redirecting to `https://github.com/cloudfoundry-community/cf-resource`.

This breaks the `github-release` resource as it does not successfully follow redirects, causing our pipeline to fail: https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/resource-types-images/builds/46

We will be opening a bug for the `github-release` resource.

Signed-off-by: Sameer Vohra <svohra@pivotal.io>
Co-authored-by: Sameer Vohra <svohra@pivotal.io>