### PR TITLE
Update concourse & release pipelines

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -832,13 +832,11 @@ jobs:
   plan:
   - in_parallel:
     - get: concourse
-      passed: [bosh-check-props]
       trigger: true
     - get: unit-image
     - get: version
-      passed: [bosh-check-props]
     - get: linux-rc-ubuntu
-      passed: [build-rc, bosh-check-props]
+      passed: [build-rc]
       trigger: true
     - get: windows-rc
       passed: [build-rc]
@@ -1115,6 +1113,7 @@ jobs:
     - bosh-topgun-runtime
     - bosh-topgun-both
     - bosh-topgun-pcf
+    - bosh-check-props
   - get: unit-image
     passed:
     - build-rc
@@ -1137,10 +1136,11 @@ jobs:
     - bosh-topgun-runtime
     - bosh-topgun-both
     - bosh-topgun-pcf
+    - bosh-check-props
   - get: linux-rc
     passed: [build-rc]
   - get: linux-rc-ubuntu
-    passed: [build-rc]
+    passed: [build-rc, bosh-check-props]
   - get: windows-rc
     passed: [build-rc]
   - get: darwin-rc

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -694,14 +694,12 @@ jobs:
   plan:
   - in_parallel:
     - get: concourse
-      passed: [bosh-check-props]
       trigger: true
     - get: unit-image
     - get: version
       trigger: true
-      passed: [bosh-check-props]
     - get: linux-rc-ubuntu
-      passed: [build-rc, bosh-check-props]
+      passed: [build-rc]
       trigger: true
     - get: windows-rc
       passed: [build-rc]
@@ -829,6 +827,7 @@ jobs:
     - build-rc
     - bosh-smoke
     - bosh-topgun
+    - bosh-check-props
   - get: unit-image
     passed:
     - build-rc
@@ -841,10 +840,11 @@ jobs:
     - build-rc
     - bosh-smoke
     - bosh-topgun
+    - bosh-check-props
   - get: linux-rc
     passed: [build-rc]
   - get: linux-rc-ubuntu
-    passed: [build-rc]
+    passed: [build-rc, bosh-check-props]
   - get: windows-rc
     passed: [build-rc]
   - get: darwin-rc


### PR DESCRIPTION
Currently our pipelines ( Concourse & Release ) block topgun tests from being run when the `bosh-check-props` job fails. 

This is not desirable as it prevents us from getting quick feedback from the topgun tests. 

The `bosh-check-props` will still prevent shipit from being run until it passes.