### PR TITLE
add version bump checking, linting, and install test

### DIFF
--- a/pipelines/helm-prs.yml
+++ b/pipelines/helm-prs.yml
@@ -128,18 +128,8 @@ jobs:
     tags: [k8s-topgun]
   - task: version-bump-check
     tags: [k8s-topgun]
+    file: ci/tasks/k8s-version-bump-check.yml
     image: unit-image
-    config:
-      platform: linux
-      inputs:
-      - name: chart-pr
-      run:
-        path: bash
-        args:
-        - -cex
-        - |
-          cd chart-pr
-          git diff master HEAD -- Chart.yaml | egrep '\+version: [0-9]+\.[0-9]+\.[0-9]+'
 
 
 - name: lint-and-install-test
@@ -171,44 +161,10 @@ jobs:
     get_params: {list_changed_files: true}
     tags: [k8s-topgun]
   - in_parallel:
-    - task: lint-check
+    - task: lint-and-install-test
       tags: [k8s-topgun]
-      image: unit-image
-      input_mapping: {concourse: chart-pr}
-      config:
-        platform: linux
-        inputs:
-        - name: concourse
-        run:
-          path: bash
-          args:
-          - -cex
-          - |
-            helm lint concourse
-    - task: basic-install-test
-      tags: [k8s-topgun]
+      file: ci/tasks/k8s-lint-and-install.yml
       image: unit-image
       input_mapping: {concourse: chart-pr}
       params:
         KUBE_CONFIG: ((topgun_kube_config))
-      config:
-        platform: linux
-        inputs:
-        - name: concourse
-        run:
-          path: bash
-          args:
-          - -ceu
-          - |
-            mkdir -p ~/.kube
-
-            if [ ! -f ~/.kube/config ]; then
-              echo "$KUBE_CONFIG" > ~/.kube/config
-            fi
-            releasename="pr-$(cat concourse/.git/resource/pr)-$(head -c 6 concourse/.git/resource/base_sha)"
-            # this needs to be updated for migrating to helm 3
-            helm init --client-only
-            helm dependency update ./concourse
-            helm install ./concourse --name "$releasename"
-            sleep 10
-            helm delete --purge "$releasename"

--- a/pipelines/helm-prs.yml
+++ b/pipelines/helm-prs.yml
@@ -95,3 +95,120 @@ jobs:
       IN_CLUSTER: "true"
       KUBE_CONFIG: ((topgun_kube_config))
       CONCOURSE_IMAGE_NAME: ((concourse_image_name))
+
+- name: version-bump-check
+  public: true
+  on_failure:
+    put: chart-pr
+    inputs: [chart-pr]
+    params: {path: chart-pr, status: failure, context: version-bump-check}
+    tags: [k8s-topgun]
+  on_success:
+    put: chart-pr
+    inputs: [chart-pr]
+    params: {path: chart-pr, status: success, context: version-bump-check}
+    tags: [k8s-topgun]
+  plan:
+  - in_parallel:
+    - get: chart-pr
+      trigger: true
+      version: every
+      tags: [k8s-topgun]
+      params:
+        integration_tool: checkout
+    - get: ci
+      tags: [k8s-topgun]
+    - get: unit-image
+      tags: [k8s-topgun]
+  - put: update-pr-status
+    resource: chart-pr
+    inputs: [chart-pr]
+    params: {path: chart-pr, status: pending, context: version-bump-check}
+    get_params: {list_changed_files: true}
+    tags: [k8s-topgun]
+  - task: version-bump-check
+    tags: [k8s-topgun]
+    image: unit-image
+    config:
+      platform: linux
+      inputs:
+      - name: chart-pr
+      run:
+        path: bash
+        args:
+        - -cex
+        - |
+          cd chart-pr
+          git diff master HEAD -- Chart.yaml | egrep '\+version: [0-9]+\.[0-9]+\.[0-9]+'
+
+
+- name: lint-and-install-test
+  public: true
+  on_failure:
+    put: chart-pr
+    inputs: [chart-pr]
+    params: {path: chart-pr, status: failure, context: lint-and-install-test}
+    tags: [k8s-topgun]
+  on_success:
+    put: chart-pr
+    inputs: [chart-pr]
+    params: {path: chart-pr, status: success, context: lint-and-install-test}
+    tags: [k8s-topgun]
+  plan:
+  - in_parallel:
+    - get: chart-pr
+      trigger: true
+      version: every
+      tags: [k8s-topgun]
+    - get: ci
+      tags: [k8s-topgun]
+    - get: unit-image
+      tags: [k8s-topgun]
+  - put: update-pr-status
+    resource: chart-pr
+    inputs: [chart-pr]
+    params: {path: chart-pr, status: pending, context: lint-and-install-test}
+    get_params: {list_changed_files: true}
+    tags: [k8s-topgun]
+  - in_parallel:
+    - task: lint-check
+      tags: [k8s-topgun]
+      image: unit-image
+      input_mapping: {concourse: chart-pr}
+      config:
+        platform: linux
+        inputs:
+        - name: concourse
+        run:
+          path: bash
+          args:
+          - -cex
+          - |
+            helm lint concourse
+    - task: basic-install-test
+      tags: [k8s-topgun]
+      image: unit-image
+      input_mapping: {concourse: chart-pr}
+      params:
+        KUBE_CONFIG: ((topgun_kube_config))
+      config:
+        platform: linux
+        inputs:
+        - name: concourse
+        run:
+          path: bash
+          args:
+          - -ceu
+          - |
+            mkdir -p ~/.kube
+
+            if [ ! -f ~/.kube/config ]; then
+              echo "$KUBE_CONFIG" > ~/.kube/config
+            fi
+            releasename="pr-$(cat concourse/.git/resource/pr)-$(head -c 6 concourse/.git/resource/base_sha)"
+            # this needs to be updated for migrating to helm 3
+            helm init --client-only
+            helm dependency update ./concourse
+            helm install ./concourse --name "$releasename"
+            sleep 10
+            helm delete --purge "$releasename"

--- a/tasks/k8s-lint-and-install.yml
+++ b/tasks/k8s-lint-and-install.yml
@@ -1,0 +1,12 @@
+---
+platform: linux
+
+params:
+  KUBE_CONFIG:
+
+inputs:
+- name: concourse
+- name: ci
+
+run:
+  path: ci/tasks/scripts/k8s-lint-and-install

--- a/tasks/k8s-version-bump-check.yml
+++ b/tasks/k8s-version-bump-check.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+
+inputs:
+- name: chart-pr
+
+run:
+  path: bash
+  args:
+  - -cex
+  - |
+    cd chart-pr
+    git diff master HEAD -- Chart.yaml | egrep '\+version: [0-9]+\.[0-9]+\.[0-9]+'

--- a/tasks/scripts/k8s-lint-and-install
+++ b/tasks/scripts/k8s-lint-and-install
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e -u
+
+mkdir -p ~/.kube
+
+if [ ! -f ~/.kube/config ]; then
+  echo "$KUBE_CONFIG" > ~/.kube/config
+fi
+
+releasename="pr-$(cat concourse/.git/resource/pr)-$(head -c 6 concourse/.git/resource/base_sha)"
+# TODO: this needs to be updated for migrating to helm 3
+helm init --client-only
+helm lint concourse
+helm dependency update ./concourse
+helm install ./concourse --name "$releasename"
+# TODO: actually poke concourse to see that it's up. For now this just ensures helm doesn't exit 1 when installing
+sleep 10
+helm delete --purge "$releasename"


### PR DESCRIPTION
We had a PR go in that somehow got through k8s-smoke and k8s-topgun,
both which set a lot of variables in the chart with --set, and broke the
default install of the chart (doing `helm install concourse/concourse`
failed).

This install test mimics the install shown in the chart README.md and
ensures coverage of that one use-case which first time users of the
chart all use. It's the chart's version of `concourse quickstart`. We
were not testing this automatically anywhere.

We still want to know why k8s-smoke and k8s-topgun didn't catch this major bug with the chart.  This investigation is being tracked in https://github.com/concourse/concourse-chart/issues/68