### PR TITLE
Moved chart version-ing back into the repo

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -1457,25 +1457,18 @@ jobs:
       passed: [k8s-topgun]
     - get: unit-image
       passed: [k8s-topgun]
-    - get: final-chart-version
-      resource: chart-version
-      params: {bump: final}
-  - put: chart-version
-    params: {file: final-chart-version/version}
 
 - name: publish-chart
   public: true
   serial: true
   plan:
   - in_parallel:
-    - get: chart-version
-      passed: [ship-chart]
-      trigger: true
     - get: concourse-version
       resource: version
       passed: [ship-chart]
     - get: concourse-chart
       passed: [ship-chart]
+      trigger: true
     - get: unit-image
       passed: [ship-chart]
     - get: chart-repo-index
@@ -1526,20 +1519,6 @@ jobs:
   serial_groups: [version]
   plan:
   - put: version
-    params: {bump: minor, pre: rc}
-
-- name: chart-major
-  public: true
-  serial_groups: [chart-version]
-  plan:
-  - put: chart-version
-    params: {bump: major, pre: rc}
-
-- name: chart-minor
-  public: true
-  serial_groups: [chart-version]
-  plan:
-  - put: chart-version
     params: {bump: minor, pre: rc}
 
 resources:
@@ -1781,15 +1760,6 @@ resources:
     bucket: concourse-artifacts
     json_key: ((concourse_artifacts_json_key))
     key: version
-
-- name: chart-version
-  type: semver
-  icon: tag
-  source:
-    driver: gcs
-    bucket: concourse-artifacts
-    json_key: ((concourse_artifacts_json_key))
-    key: chart-version
 
 - name: linux-rc
   type: gcs

--- a/tasks/scripts/package-chart
+++ b/tasks/scripts/package-chart
@@ -6,24 +6,6 @@ set -e -x
 # can be renamed to 'bumped-chart' or something more sensible once we're on helm v3
 git clone ./concourse-chart ./concourse
 
-chart_version=$(cat chart-version/version)
-concourse_version=$(cat concourse-version/version)
-
-pushd concourse
-  sed -i "s/version: .*/version: ${chart_version}/g" Chart.yaml
-  sed -i "s/appVersion: .*/appVersion: ${concourse_version}/g" Chart.yaml
-  sed -i "s/imageTag: .*/imageTag: \"${concourse_version}\"/g" values.yaml
-  sed -i "s/Concourse image version | .* |/Concourse image version | \`${concourse_version}\` |/g" README.md
-
-  git config --global user.email "ci@localhost"
-  git config --global user.name "CI Bot"
-
-  git add -A
-  git commit -m "bump chart version"
-  git tag -f "v$chart_version"
-popd
-
-
 helm init --client-only
 helm repo remove local
 helm repo update


### PR DESCRIPTION
It was confusing having it happen outside of the repo for OSS users of
the chart. From their perspective it was unclear how or when releases
were happening. This slowly moves us back to releasing on every commit.