### PR TITLE
scripts: add `osusergo` to tags when building fly

### DIFF
--- a/tasks/scripts/fly-build
+++ b/tasks/scripts/fly-build
@@ -27,7 +27,7 @@ pushd concourse
     fi
   fi
 
-  go build --tags netgo -a -ldflags "$ldflags" -o $output/fly ./fly
+  go build --tags 'netgo osusergo' -a -ldflags "$ldflags" -o $output/fly ./fly
 
   if [ "$platform" = "linux" ] && which ldd && ldd $output/fly; then
     echo "binary is not static; aborting"


### PR DESCRIPTION
with the introduction of the pure-go ZSTD lib (#5024), there might be
something new that's importing `os/user`, which ends up forcing a
dynamic build.

by adding the `osusergo` tag to the build of `fly`, we can instead
leverage the go-based implementation, and thus, have a static build of
`fly`.

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>