### PR TITLE
add testflight-containerd job

### DIFF
--- a/pipelines/prs.yml
+++ b/pipelines/prs.yml
@@ -163,6 +163,7 @@ jobs:
       params: {format: oci}
       tags: [pr]
     - get: ci
+      tags: [pr]
   - put: concourse-status-update
     resource: concourse-pr
     inputs: [concourse-pr]
@@ -181,6 +182,54 @@ jobs:
     input_mapping: {concourse: built-concourse}
     params: {BUILD: true}
     tags: [pr]
+
+- name: testflight-containerd
+  public: true
+  max_in_flight: 3
+  on_failure:
+    put: concourse-pr
+    inputs: [concourse-pr]
+    params: {path: concourse-pr, status: failure, context: testflight-containerd}
+    tags: [pr]
+    get_params: {skip_download: true}
+  on_success:
+    put: concourse-pr
+    inputs: [concourse-pr]
+    params: {path: concourse-pr, status: success, context: testflight-containerd}
+    tags: [pr]
+    get_params: {skip_download: true}
+  plan:
+    - in_parallel:
+        - get: concourse-pr
+          trigger: true
+          version: every
+          tags: [pr]
+        - get: dev-image
+          params: {format: oci}
+          tags: [pr]
+        - get: postgres-image
+          params: {format: oci}
+          tags: [pr]
+        - get: ci
+          tags: [pr]
+    - put: concourse-status-update
+      resource: concourse-pr
+      inputs: [concourse-pr]
+      params: {path: concourse-pr, status: pending, context: testflight-containerd}
+      tags: [pr]
+      get_params: {list_changed_files: true, skip_download: true}
+    - task: yarn-build
+      attempts: 3
+      file: ci/tasks/yarn-build.yml
+      input_mapping: {concourse: concourse-pr}
+      tags: [pr]
+    - task: testflight
+      timeout: 1h
+      privileged: true
+      file: ci/tasks/docker-compose-testflight.yml
+      input_mapping: {concourse: built-concourse}
+      params: {BUILD: true, CONTAINERD: true}
+      tags: [pr]
 
 - name: watsjs
   public: true

--- a/tasks/docker-compose-testflight.yml
+++ b/tasks/docker-compose-testflight.yml
@@ -18,6 +18,7 @@ caches:
 
 params:
   BUILD:
+  CONTAINERD:
 
 run:
   path: ci/tasks/scripts/pass-release-notes-only-change

--- a/tasks/scripts/with-docker-compose
+++ b/tasks/scripts/with-docker-compose
@@ -11,22 +11,24 @@ start_docker
 
 export CONCOURSE_DEV_TAG=$(cat dev-image/tag)
 
-pushd concourse
-  if [ "$BUILD" = "true" ]; then
-    docker-compose \
-      -f docker-compose.yml \
-      -f ../ci/overrides/docker-compose.ci.yml \
-      up --build -d
-  else
-    ../ci/tasks/scripts/generate-keys
+DOCKER_COMPOSE_FLAGS="-f concourse/docker-compose.yml -f ci/overrides/docker-compose.ci.yml"
 
-    docker-compose \
-      -f docker-compose.yml \
-      -f ../ci/overrides/docker-compose.ci.yml \
-      -f ../ci/overrides/docker-compose.no-build.yml \
-      up --no-build -d
-  fi
-popd
+if [ "$CONTAINERD" = "true" ]; then
+  DOCKER_COMPOSE_FLAGS="$DOCKER_COMPOSE_FLAGS -f concourse/hack/overrides/containerd.yml"
+fi
+
+if [ "$BUILD" = "true" ]; then
+  docker-compose \
+    $DOCKER_COMPOSE_FLAGS \
+    up --build -d
+else
+  ci/tasks/scripts/generate-keys
+
+  docker-compose \
+    $DOCKER_COMPOSE_FLAGS \
+    -f ci/overrides/docker-compose.no-build.yml \
+    up --no-build -d
+fi
 
 trap stop_docker_compose EXIT SIGTERM SIGINT
 function stop_docker_compose() {


### PR DESCRIPTION
Added a job in the `prs` pipeline to run testflight suite with containerd as the runtime.

#267

It's currently running in the [prs-test](https://ci.concourse-ci.org/teams/main/pipelines/prs-test) pipeline. Here's an example of a PR that it ran against:  https://github.com/concourse/concourse/pull/5237. Note that there's an additional `testflight-containerd` check that is passing.