### PR TITLE
download fly cli in testflight for release pipelines

### DIFF
--- a/pipelines/prs.yml
+++ b/pipelines/prs.yml
@@ -180,7 +180,7 @@ jobs:
     privileged: true
     file: ci/tasks/docker-compose-testflight.yml
     input_mapping: {concourse: built-concourse}
-    params: {BUILD: true}
+    params: {BUILD: true, DOWNLOAD_CLI: false}
     tags: [pr]
 
 - name: testflight-containerd

--- a/tasks/docker-compose-testflight.yml
+++ b/tasks/docker-compose-testflight.yml
@@ -19,6 +19,7 @@ caches:
 params:
   BUILD:
   CONTAINERD:
+  DOWNLOAD_CLI: true
 
 run:
   path: ci/tasks/scripts/pass-release-notes-only-change


### PR DESCRIPTION
Rather than building `fly` in testflight for our release pipelines, we
should be downloading the CLI from ATC. This lets us exercise the actual
fly binary that gets bundled with Concourse (and can help us detect bugs
with the flags we use to build fly early)

For our PR pipeline, we do not want to download fly, and instead want to
build it. This is because a PR may make changes to fly, and we want to
run the tests against the updated code (rather than what was baked into
the `concourse/dev` image).

Extends concourse/concourse#5266

Signed-off-by: Aidan Oldershaw <aoldershaw@pivotal.io>
Co-authored-by: Rui Yang <ryang@pivotal.io>