### PR TITLE
topgun: add uaa (release and concourse pipelines)

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -931,6 +931,8 @@ jobs:
       trigger: true
     - get: credhub-release
       trigger: true
+    - get: uaa-release
+      trigger: true
     - get: bbr
       trigger: true
     - get: ci
@@ -979,6 +981,8 @@ jobs:
     - get: vault-release
       trigger: true
     - get: credhub-release
+      trigger: true
+    - get: uaa-release
       trigger: true
     - get: bbr
       trigger: true
@@ -1029,6 +1033,8 @@ jobs:
       trigger: true
     - get: credhub-release
       trigger: true
+    - get: uaa-release
+      trigger: true
     - get: bbr
       trigger: true
     - get: ci
@@ -1077,6 +1083,8 @@ jobs:
     - get: vault-release
       trigger: true
     - get: credhub-release
+      trigger: true
+    - get: uaa-release
       trigger: true
     - get: bbr
       trigger: true
@@ -1856,6 +1864,12 @@ resources:
   icon: *release-icon
   source:
     repository: pivotal-cf/credhub-release
+
+- name: uaa-release
+  type: bosh-io-release
+  icon: *release-icon
+  source:
+    repository: cloudfoundry/uaa-release
 
 - name: concourse-release-repo
   type: git

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -793,6 +793,8 @@ jobs:
       trigger: true
     - get: credhub-release
       trigger: true
+    - get: uaa-release
+      trigger: true
     - get: bbr
       trigger: true
     - get: ci
@@ -1423,6 +1425,11 @@ resources:
   type: bosh-io-release
   icon: *release-icon
   source: {repository: pivotal-cf/credhub-release}
+
+- name: uaa-release
+  type: bosh-io-release
+  icon: *release-icon
+  source: {repository: cloudfoundry/uaa-release}
 
 - name: bbr-sdk-release
   type: bosh-io-release

--- a/tasks/scripts/topgun
+++ b/tasks/scripts/topgun
@@ -11,6 +11,7 @@ export BPM_RELEASE_VERSION="$(cat bpm-release/version)"
 export POSTGRES_RELEASE_VERSION="$(cat postgres-release/version)"
 export VAULT_RELEASE_VERSION="$(cat vault-release/version)"
 export CREDHUB_RELEASE_VERSION="$(cat credhub-release/version)"
+export UAA_RELEASE_VERSION="$(cat uaa-release/version)"
 export BACKUP_AND_RESTORE_SDK_RELEASE_VERSION="$(cat bbr-sdk-release/version)"
 export STEMCELL_VERSION="$(cat stemcell/version)"
 
@@ -35,6 +36,7 @@ bosh upload-release bpm-release/*.tgz
 bosh upload-release postgres-release/*.tgz
 bosh upload-release vault-release/*.tgz
 bosh upload-release credhub-release/*.tgz
+bosh upload-release uaa-release/*.tgz
 bosh upload-release bbr-sdk-release/*.tgz
 bosh upload-stemcell stemcell/*.tgz
 

--- a/tasks/topgun.yml
+++ b/tasks/topgun.yml
@@ -25,6 +25,7 @@ inputs:
 - name: concourse
 - name: concourse-release
 - name: credhub-release
+- name: uaa-release
 - name: postgres-release
 - name: stemcell
 - name: vault-release


### PR DESCRIPTION
in https://github.com/concourse/concourse/pull/5255, `uaa` was added to
the set of releases necessary for a complete run of `topgun`.

these changes allows us to keep track of the releases of UAA that we're
using when running those tests, as well as allowing our task to upload
that to the BOSH director.


`concourse`:

<img width="629" alt="Screen Shot 2020-03-03 at 1 47 32 PM" src="https://user-images.githubusercontent.com/3574444/75808776-a7615a80-5d55-11ea-8f15-1ad0902f8b60.png">

`release`:

<img width="508" alt="Screen Shot 2020-03-03 at 1 48 09 PM" src="https://user-images.githubusercontent.com/3574444/75808798-adefd200-5d55-11ea-844f-7c04c18c00fa.png">



Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>