### PR TITLE
slack-notify will alert on every job failure for release pipelines.

### DIFF
--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -121,7 +121,7 @@ jobs:
     - task: fly-windows
       file: ci/tasks/fly-windows.yml
       timeout: 1h
-  on_success: &fixed-concourse
+  on_failure: &failed-concourse
     do:
     - task: format-slack-message
       file: ci/tasks/format-slack-message.yml
@@ -133,20 +133,7 @@ jobs:
       params:
         message_file: message/message
         mode: normal
-        alert_type: fixed
-  on_failure: &broke-concourse
-    do:
-    - task: format-slack-message
-      file: ci/tasks/format-slack-message.yml
-      input_mapping: {src: concourse}
-      params:
-        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
-        SLACK_TOKEN: ((slack_token))
-    - put: notify
-      params:
-        message_file: message/message
-        mode: normal
-        alert_type: broke
+        alert_type: failed
 
 - name: resource-types-images
   public: true
@@ -247,8 +234,7 @@ jobs:
   - put: dev-image
     params: {image: image/image.tar}
     get_params: {format: oci}
-  on_success: *fixed-concourse
-  on_failure: *broke-concourse
+  on_failure: *failed-concourse
 
 - name: testflight
   public: true
@@ -272,8 +258,7 @@ jobs:
     privileged: true
     timeout: 1h
     file: ci/tasks/docker-compose-testflight.yml
-  on_success: *fixed-concourse
-  on_failure: *broke-concourse
+  on_failure: *failed-concourse
 
 - name: watsjs
   public: true
@@ -297,8 +282,7 @@ jobs:
     privileged: true
     timeout: 1h
     file: ci/tasks/docker-compose-watsjs.yml
-  on_success: *fixed-concourse
-  on_failure: *broke-concourse
+  on_failure: *failed-concourse
 
 - name: upgrade
   public: true
@@ -322,8 +306,7 @@ jobs:
     privileged: true
     image: unit-image
     file: ci/tasks/upgrade-test.yml
-  on_success: *fixed-concourse
-  on_failure: *broke-concourse
+  on_failure: *failed-concourse
 
 - name: downgrade
   public: true
@@ -377,8 +360,7 @@ jobs:
     image: unit-image
     input_mapping: {distribution: concourse-chart, linux-rc: linux-rc-ubuntu}
     params: {DISTRIBUTION: helm}
-  on_success: *fixed-concourse
-  on_failure: *broke-concourse
+  on_failure: *failed-concourse
 
 - name: k8s-smoke
   public: true
@@ -433,8 +415,7 @@ jobs:
       KUBE_CONFIG: ((kube_config))
       RELEASE_NAME: ((concourse_smoke_deployment_name))
       CONCOURSE_IMAGE: concourse/concourse-rc
-  on_success: *fixed-concourse
-  on_failure: *broke-concourse
+  on_failure: *failed-concourse
 
 - name: k8s-topgun
   public: true
@@ -477,8 +458,7 @@ jobs:
       IN_CLUSTER: "true"
       KUBE_CONFIG: ((kube_config))
       CONCOURSE_IMAGE_NAME: concourse/concourse-rc
-  on_success: *fixed-concourse
-  on_failure: *broke-concourse
+  on_failure: *failed-concourse
 
 - name: rc
   public: true
@@ -623,8 +603,7 @@ jobs:
           params:
             image: image-ubuntu/image.tar
             additional_tags: version/version
-  on_success: *fixed-concourse
-  on_failure: *broke-concourse
+  on_failure: *failed-concourse
 
 - name: bin-smoke
   public: true
@@ -656,8 +635,7 @@ jobs:
     image: unit-image
     file: ci/tasks/smoke.yml
     input_mapping: {endpoint-info: outputs}
-  on_success: *fixed-concourse
-  on_failure: *broke-concourse
+  on_failure: *failed-concourse
 
 - name: bosh-check-props
   public: true
@@ -761,8 +739,7 @@ jobs:
     tags: [bosh]
     image: unit-image
     file: ci/tasks/smoke.yml
-  on_success: *fixed-concourse
-  on_failure: *broke-concourse
+  on_failure: *failed-concourse
 
 - name: bosh-topgun
   public: true
@@ -812,8 +789,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ((topgun_aws_ssm.access_key_id))
       AWS_SECRET_ACCESS_KEY: ((topgun_aws_ssm.secret_access_key))
       SKIP_PACKAGES: "k8s"
-  on_success: *fixed-concourse
-  on_failure: *broke-concourse
+  on_failure: *failed-concourse
 
 - name: shipit
   public: true


### PR DESCRIPTION
Currently, slack-notify resource will alert when a job has been fixed and also, when it breaks after a successful run (alert types: fixed/broke). 

However, we think that is more relevant to alert about job failures every time they occur in a release pipeline. When managing a release, every job failure should be brought to the
attention of the team/anchor release as stated in the Github issue #5263.

Co-authored-by: Izabela Gomes <igomes@pivotal.io>
Signed-off-by: Izabela Gomes <igomes@pivotal.io>
Co-authored-by: Ciro S. Costa <cscosta@pivotal.io>