### PR TITLE
Add job to discover installed versions of Postgresql and Helm in the unit image

### DIFF
--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -606,37 +606,6 @@ jobs:
             additional_tags: version/version
   on_failure: *failed-concourse
 
-- name: discover-component-version
-  public: true
-  serial: true
-  plan:
-  - in_parallel:
-    - get: concourse
-      passed: [build-rc-image]
-      trigger: true
-    - get: unit-image
-      passed: [build-rc-image]
-      trigger: true
-    - get: version
-      passed: [build-rc-image]
-      trigger: true
-  - task: discover-postgresql-version
-    file: ci/tasks/discover-component-version.yml
-    inputs: [version]
-    output_mapping: {component-version: postgresql-version}
-    params: {COMPONENT_NAME: "postgresql"}
-  - task: discover-helm-version
-    file: ci/tasks/discover-component-version.yml
-    inputs: [version]
-    output_mapping: {component-version: helm-version}
-    params: {COMPONENT_NAME: "helm"}
-  - put: resource-postgresql-version
-    inputs: [postgresql-version]
-    params: {file: "postgresql-version/postgresql-version-*.txt"}
-  - put: resource-helm-version
-    inputs: [helm-version]
-    params: {file: "helm-version/helm-version-*.txt"}
-
 - name: bin-smoke
   public: true
   serial: true
@@ -868,6 +837,36 @@ jobs:
       passed: [bosh-smoke, bosh-topgun]
   - put: version
     params: {file: final-version/version}
+
+- name: discover-component-version
+  public: true
+  serial: true
+  plan:
+    - in_parallel:
+      - get: concourse
+        passed: [shipit]
+        trigger: true
+      - get: unit-image
+        passed: [shipit]
+        trigger: true
+      - get: version
+        passed: [shipit]
+    - task: discover-postgresql-version
+      file: ci/tasks/discover-component-version.yml
+      inputs: [version]
+      output_mapping: {component-version: postgresql-version}
+      params: {COMPONENT_NAME: "postgresql"}
+    - task: discover-helm-version
+      file: ci/tasks/discover-component-version.yml
+      inputs: [version]
+      output_mapping: {component-version: helm-version}
+      params: {COMPONENT_NAME: "helm"}
+    - put: resource-postgresql-version
+      inputs: [postgresql-version]
+      params: {file: "postgresql-version/postgresql-version-*.txt"}
+    - put: resource-helm-version
+      inputs: [helm-version]
+      params: {file: "helm-version/helm-version-*.txt"}
 
 - name: publish-binaries
   serial: true

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -68,6 +68,7 @@ groups:
   - bin-smoke
   - upgrade
   - downgrade
+  - discover-component-version
 
 - name: k8s
   jobs:
@@ -604,6 +605,37 @@ jobs:
             image: image-ubuntu/image.tar
             additional_tags: version/version
   on_failure: *failed-concourse
+
+- name: discover-component-version
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [build-rc-image]
+      trigger: true
+    - get: unit-image
+      passed: [build-rc-image]
+      trigger: true
+    - get: version
+      passed: [build-rc-image]
+      trigger: true
+  - task: discover-postgresql-version
+    file: ci/tasks/discover-component-version.yml
+    inputs: [version]
+    output_mapping: {component-version: postgresql-version}
+    params: {COMPONENT_NAME: "postgresql"}
+  - task: discover-helm-version
+    file: ci/tasks/discover-component-version.yml
+    inputs: [version]
+    output_mapping: {component-version: helm-version}
+    params: {COMPONENT_NAME: "helm"}
+  - put: resource-postgresql-version
+    inputs: [postgresql-version]
+    params: {file: "postgresql-version/postgresql-version-*.txt"}
+  - put: resource-helm-version
+    inputs: [helm-version]
+    params: {file: "helm-version/helm-version-*.txt"}
 
 - name: bin-smoke
   public: true
@@ -1532,6 +1564,22 @@ resources:
     bucket: concourse-ubuntu-dpkg-list
     json_key: ((concourse_dpkg_list_json_key))
     regexp: "concourse-dpkg-list-(.*).txt"
+
+- name: resource-postgresql-version
+  type: gcs
+  icon: format-list-bulleted
+  source:
+    bucket: concourse-components-version
+    json_key: ((concourse_components_json_key))
+    regexp: "postgresql-version-(.*).txt"
+
+- name: resource-helm-version
+  type: gcs
+  icon: format-list-bulleted
+  source:
+    bucket: concourse-components-version
+    json_key: ((concourse_components_json_key))
+    regexp: "helm-version-(.*).txt"
 
 - name: chart-repo
   type: gcs

--- a/tasks/discover-component-version.yml
+++ b/tasks/discover-component-version.yml
@@ -1,0 +1,31 @@
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/unit}
+
+inputs:
+  - name: version
+
+outputs:
+  - name: component-version
+
+params:
+  COMPONENT_NAME: ~
+
+run:
+  path: /bin/bash
+  args:
+    - -cex
+    - |
+
+      if [[ -d ./version ]]; then
+        CONCOURSE_VERSION=$(cat ./version/version)
+      fi
+
+      if [ $COMPONENT_NAME == "helm" ]; then
+        helm version --client --template "{{.Client.SemVer}}" > ./component-version/helm-version-${CONCOURSE_VERSION}.txt
+      else
+        dpkg -l | grep "${COMPONENT_NAME}-[0-9]\.*.*[0-9]*" | awk '$1=="ii" { print $3 }' | cut -d. -f1,2
+          > ./component-version/${COMPONENT_NAME}-version-${CONCOURSE_VERSION}.txt
+      fi


### PR DESCRIPTION
Added job `discover-components-version` to find out installed versions of Postgresql and Helm in the unit image.

- Created GCS bucket called `concourse-components-version`
- Added job that saves two files to the bucket. One for postgres
and the other for helm. Filename consists of [app name]-version-[concourse version].txt
and the content is the actual app version installed in the unit image
(eg. helm-version-5.5.8.txt has v2.16.3 as its contents).
- Used the same filename convention as files in the `concourse-ubuntu-dpkg-list` bucket

Solves issue https://github.com/concourse/ci/issues/286

Signed-off-by: Izabela Gomes <igomes@pivotal.io>