### PR TITLE
Added time-resource to release pipelines to ensure periodic run

### DIFF
--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -105,6 +105,8 @@ jobs:
       trigger: true
     - get: unit-image
       trigger: true
+    - get: periodic-check
+      trigger: true
     - get: ci
   - task: yarn-test
     image: unit-image
@@ -169,6 +171,8 @@ jobs:
     - get: mock-resource
       trigger: true
     - get: builder
+      trigger: true
+    - get: periodic-check
       trigger: true
     - get: ci
   - in_parallel:
@@ -1555,3 +1559,10 @@ resources:
     bucket: concourse-artifacts
     json_key: ((concourse_artifacts_json_key))
     key: chart-version-((release_minor))
+
+- name: periodic-check
+  type: time
+  source:
+    start: 2AM
+    stop: 3AM
+    interval: 1h


### PR DESCRIPTION
We want to make sure release pipelines are continuously running so, we can quickly release a new version when needed.

We added a time-resource that will trigger two jobs every night. It solves #291 

Signed-off-by: Izabela Gomes <igomes@pivotal.io>
Co-authored-by: Bishoy Youssef <byoussef@pivotal.io>