### PR TITLE
fix 5.x release pipelines without packing in containerd

### DIFF
--- a/dockerfiles/dev-legacy/Dockerfile
+++ b/dockerfiles/dev-legacy/Dockerfile
@@ -4,7 +4,6 @@
 # * baking in the containerd binaries (+ runc, cni plugins, iptables)
 # * baking in fly binaries
 # * baking in resource types
-# * build init executable for containerd
 # * warming the module cache
 # * warming the build cache
 
@@ -24,11 +23,6 @@ RUN chmod +x /usr/local/bin/dumb-init
 #
 # For guardian backend:
 #   - gdn
-# For containerd backend:
-#   - containerd binaries
-#   - runc
-#   - cni plugins
-#   - iptables (needed by cni plugins)
 COPY gdn/gdn-* /usr/local/concourse/bin/gdn
 
 RUN chmod -R +x /usr/local/concourse/bin
@@ -47,10 +41,6 @@ COPY ./resource-types-image/rootfs/usr/local/concourse/resource-types/ /usr/loca
 # nuke /src after to ensure dev builds build from a clean slate (otherwise this
 # can cause build failures if e.g. files are removed locally)
 COPY concourse /src
-
-# build the init executable for containerd
-RUN  set -x && \
-	gcc -O2 -static -o /usr/local/concourse/bin/init /src/cmd/init/init.c
 
 RUN cd /src && \
       go mod download && \

--- a/dockerfiles/dev-legacy/Dockerfile
+++ b/dockerfiles/dev-legacy/Dockerfile
@@ -1,0 +1,81 @@
+# used for building concourse/dev. this shortens the dev feedback loop by:
+#
+# * baking in the gdn binary
+# * baking in the containerd binaries (+ runc, cni plugins, iptables)
+# * baking in fly binaries
+# * baking in resource types
+# * build init executable for containerd
+# * warming the module cache
+# * warming the build cache
+
+FROM concourse/golang-builder
+
+RUN apt-get update && apt-get -y install \
+      iproute2 \
+      ca-certificates \
+      file \
+      tree \
+      btrfs-tools
+
+COPY dumb-init/dumb-init_*_amd64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
+
+# Add container runtime dependencies
+#
+# For guardian backend:
+#   - gdn
+# For containerd backend:
+#   - containerd binaries
+#   - runc
+#   - cni plugins
+#   - iptables (needed by cni plugins)
+COPY gdn/gdn-* /usr/local/concourse/bin/gdn
+
+RUN chmod -R +x /usr/local/concourse/bin
+
+# add fly executables
+RUN mkdir /usr/local/concourse/fly-assets
+COPY fly-linux/fly-*.tgz /usr/local/concourse/fly-assets
+COPY fly-windows/fly-*.zip /usr/local/concourse/fly-assets
+COPY fly-darwin/fly-*.tgz /usr/local/concourse/fly-assets
+
+# add resource types
+COPY ./resource-types-image/rootfs/usr/local/concourse/resource-types/ /usr/local/concourse/resource-types/
+
+# install concourse, leaving the module cache populated
+#
+# nuke /src after to ensure dev builds build from a clean slate (otherwise this
+# can cause build failures if e.g. files are removed locally)
+COPY concourse /src
+
+# build the init executable for containerd
+RUN  set -x && \
+	gcc -O2 -static -o /usr/local/concourse/bin/init /src/cmd/init/init.c
+
+RUN cd /src && \
+      go mod download && \
+      go install github.com/gobuffalo/packr/packr && \
+      packr build -gcflags=all="-N -l" -o /usr/local/concourse/bin/concourse \
+        ./cmd/concourse && \
+      rm -rf /src
+
+# volume for non-aufs/etc. mount for baggageclaim's driver
+VOLUME /worker-state
+ENV CONCOURSE_WORK_DIR /worker-state
+
+# enable DNS proxy to support Docker's 127.x.x.x DNS server
+ENV CONCOURSE_GARDEN_DNS_PROXY_ENABLE true
+
+# 'web' keys
+ENV CONCOURSE_SESSION_SIGNING_KEY     /concourse-keys/session_signing_key
+ENV CONCOURSE_TSA_AUTHORIZED_KEYS     /concourse-keys/authorized_worker_keys
+ENV CONCOURSE_TSA_HOST_KEY            /concourse-keys/tsa_host_key
+
+# 'worker' keys
+ENV CONCOURSE_TSA_PUBLIC_KEY          /concourse-keys/tsa_host_key.pub
+ENV CONCOURSE_TSA_WORKER_PRIVATE_KEY  /concourse-keys/worker_key
+
+# set $PATH for convenience
+ENV PATH /usr/local/concourse/bin:${PATH}
+
+ENTRYPOINT ["dumb-init", "concourse"]

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -145,7 +145,7 @@ jobs:
   - set_pipeline: norsk-mirror
     file: pipelines-and-tasks/pipelines/norsk-mirror.yml
   - set_pipeline: release-5.2.x
-    file: pipelines-and-tasks/pipelines/release.yml
+    file: pipelines-and-tasks/pipelines/release-legacy.yml
     vars:
       release_major: "5"
       release_minor: "5.2"
@@ -153,7 +153,7 @@ jobs:
       concourse_smoke_deployment_name: "concourse-smoke-5-2"
       bin_smoke_use_https: "false"
   - set_pipeline: release-5.5.x
-    file: pipelines-and-tasks/pipelines/release.yml
+    file: pipelines-and-tasks/pipelines/release-legacy.yml
     vars:
       release_major: "5"
       release_minor: "5.5"
@@ -161,13 +161,21 @@ jobs:
       concourse_smoke_deployment_name: "concourse-smoke-5-5"
       bin_smoke_use_https: "true"
   - set_pipeline: release-5.7.x
-    file: pipelines-and-tasks/pipelines/release.yml
+    file: pipelines-and-tasks/pipelines/release-legacy.yml
     vars:
       release_major: "5"
       release_minor: "5.7"
       latest_release: "5.7"
       concourse_smoke_deployment_name: "concourse-smoke-5-7"
       bin_smoke_use_https: "true"
+  - set_pipeline: release-5.8.x
+      file: pipelines-and-tasks/pipelines/release-legacy.yml
+      vars:
+        release_major: "5"
+        release_minor: "5.8"
+        latest_release: "5.8"
+        concourse_smoke_deployment_name: "concourse-smoke-5-8"
+        bin_smoke_use_https: "true"
   - set_pipeline: release-6.0.x
     file: pipelines-and-tasks/pipelines/release.yml
     vars:

--- a/pipelines/release-legacy.yml
+++ b/pipelines/release-legacy.yml
@@ -537,13 +537,13 @@ jobs:
       fail_fast: true
       steps:
       - task: concourse-linux-alpine
-        file: ci/tasks/concourse-build-linux.yml
+        file: ci/tasks/concourse-build-linux-legacy.yml
         image: unit-image
         input_mapping: {concourse: built-concourse, resource-types: resource-types-alpine}
         output_mapping: {concourse-tarball: concourse-linux-alpine}
       - task: concourse-linux-ubuntu
         image: unit-image
-        file: ci/tasks/concourse-build-linux.yml
+        file: ci/tasks/concourse-build-linux-legacy.yml
         input_mapping: {concourse: built-concourse, resource-types: resource-types-ubuntu}
         output_mapping: {concourse-tarball: concourse-linux-ubuntu}
       - task: concourse-windows

--- a/pipelines/release-legacy.yml
+++ b/pipelines/release-legacy.yml
@@ -1,0 +1,1580 @@
+# the following vars must be specified:
+#
+#   ((release_major))                   the MAJOR version, e.g. 5
+#   ((release_minor))                   the MAJOR.MINOR version, e.g. 5.1
+#                                       concourse matches the desired release version
+#   ((concourse_smoke_deployment_name)) a unique name for the smoke bosh deployment
+#
+# the following git branches need to be created:
+#
+#   concourse/concourse                 release/((release_minor)).x
+#   concourse/concourse-bosh-release    release/((release_minor)).x
+#
+# everything else will be managed by the pipeline
+
+resource_types:
+- name: gcs
+  type: registry-image
+  source: {repository: frodenas/gcs-resource}
+
+# needed for 'tag' file creation; can be removed once shipped
+- name: registry-image
+  type: registry-image
+  source: {repository: concourse/registry-image-resource}
+
+- name: bosh-release
+  type: registry-image
+  source: {repository: dpb587/bosh-release-resource}
+
+- name: bosh-deployment
+  type: registry-image
+  source: {repository: cloudfoundry/bosh-deployment-resource}
+
+- name: github-release
+  type: registry-image
+  source: {repository: concourse/github-release-resource}
+
+- name: semver
+  type: registry-image
+  source: {repository: concourse/semver-resource}
+
+- name: s3
+  type: registry-image
+  source: {repository: concourse/s3-resource}
+
+- name: bosh-io-release
+  type: registry-image
+  source: {repository: concourse/bosh-io-release-resource}
+
+- name: bosh-io-stemcell
+  type: registry-image
+  source: {repository: concourse/bosh-io-stemcell-resource}
+
+- name: slack-notifier
+  type: registry-image
+  source: {repository: mockersf/concourse-slack-notifier}
+
+groups:
+- name: develop
+  jobs:
+  - unit
+  - resource-types-images
+  - dev-image
+  - testflight
+  - watsjs
+  - rc
+  - build-rc
+  - build-rc-image
+  - bin-smoke
+  - upgrade
+  - downgrade
+
+- name: k8s
+  jobs:
+  - k8s-check-helm-params
+  - k8s-smoke
+  - k8s-topgun
+
+- name: bosh
+  jobs:
+  - bosh-bump
+  - bosh-smoke
+  - bosh-topgun
+  - bosh-check-props
+
+- name: publish
+  jobs:
+  - shipit
+  - publish-binaries
+  - publish-image
+  - publish-bosh-release
+  - bump-cbd-versions
+  - publish-docs
+  - ship-chart
+  - publish-chart
+  - patch
+  - chart-patch
+
+jobs:
+- name: unit
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse
+      trigger: true
+    - get: unit-image
+      trigger: true
+    - get: periodic-check
+      trigger: true
+    - get: ci
+  - task: yarn-test
+    image: unit-image
+    file: ci/tasks/yarn-test.yml
+  - in_parallel:
+    - task: unit
+      image: unit-image
+      file: ci/tasks/unit.yml
+      input_mapping: {concourse: built-concourse}
+      timeout: 1h
+    - task: fly-darwin
+      file: ci/tasks/fly-darwin.yml
+      timeout: 1h
+    - task: fly-windows
+      file: ci/tasks/fly-windows.yml
+      timeout: 1h
+  on_failure: &failed-concourse
+    do:
+    - task: format-slack-message
+      file: ci/tasks/format-slack-message.yml
+      input_mapping: {src: concourse}
+      params:
+        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
+        SLACK_TOKEN: ((slack_token))
+    - put: notify
+      params:
+        message_file: message/message
+        mode: normal
+        alert_type: failed
+  on_error: *failed-concourse
+
+- name: resource-types-images
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: bosh-io-release-resource
+      trigger: true
+    - get: bosh-io-stemcell-resource
+      trigger: true
+    - get: cf-resource
+      trigger: true
+    - get: docker-image-resource
+      trigger: true
+    - get: git-resource
+      trigger: true
+    - get: github-release-resource
+      trigger: true
+    - get: hg-resource
+      trigger: true
+    - get: pool-resource
+      trigger: true
+    - get: registry-image-resource
+      trigger: true
+    - get: s3-resource
+      trigger: true
+    - get: semver-resource
+      trigger: true
+    - get: time-resource
+      trigger: true
+    - get: tracker-resource
+      trigger: true
+    - get: mock-resource
+      trigger: true
+    - get: builder
+      trigger: true
+    - get: periodic-check
+      trigger: true
+    - get: ci
+  - in_parallel:
+    - task: build-alpine
+      image: builder
+      privileged: true
+      params:
+        BUILD_ARG_distro: alpine
+      file: ci/tasks/build-resource-types-image.yml
+    - task: build-ubuntu
+      output_mapping: {image: image_ubuntu}
+      image: builder
+      privileged: true
+      params:
+        BUILD_ARG_distro: ubuntu
+      file: ci/tasks/build-resource-types-image.yml
+  - in_parallel:
+    - put: resource-types-alpine-image
+      params: {image: image/image.tar}
+      get_params: {format: oci}
+    - put: resource-types-ubuntu-image
+      params: {image: image_ubuntu/image.tar}
+      get_params: {format: oci}
+
+- name: dev-image
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+      fail_fast: true
+      steps:
+      - get: concourse
+        trigger: true
+      - get: unit-image
+        trigger: true
+      - get: gdn
+        trigger: true
+      - get: dumb-init
+        trigger: true
+      - get: resource-types-alpine-image
+        passed: [resource-types-images]
+        trigger: true
+      - get: builder
+      - get: ci
+  - in_parallel:
+      fail_fast: true
+      steps:
+      - task: yarn-build
+        image: unit-image
+        file: ci/tasks/yarn-build.yml
+      - task: fly-linux
+        file: ci/tasks/fly-build-linux.yml
+        image: unit-image
+      - task: fly-windows
+        file: ci/tasks/fly-build-windows.yml
+      - task: fly-darwin
+        file: ci/tasks/fly-build-darwin.yml
+  - task: build
+    image: builder
+    privileged: true
+    input_mapping: {concourse: built-concourse, resource-types-image: resource-types-alpine-image}
+    file: ci/tasks/build-dev-image-legacy.yml
+  - put: dev-image
+    params: {image: image/image.tar}
+    get_params: {format: oci}
+  on_failure: *failed-concourse
+  on_error: *failed-concourse
+
+- name: testflight
+  public: true
+  max_in_flight: 2
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [unit, dev-image]
+      trigger: true
+    - get: dev-image
+      passed: [dev-image]
+      params: {format: oci}
+      trigger: true
+    - get: unit-image
+      passed: [unit, dev-image]
+    - get: postgres-image
+      params: {format: oci}
+    - get: ci
+  - task: testflight
+    image: unit-image
+    privileged: true
+    timeout: 1h
+    file: ci/tasks/docker-compose-testflight.yml
+  on_failure: *failed-concourse
+  on_error: *failed-concourse
+
+- name: watsjs
+  public: true
+  max_in_flight: 2
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [unit, dev-image]
+      trigger: true
+    - get: dev-image
+      passed: [dev-image]
+      params: {format: oci}
+      trigger: true
+    - get: unit-image
+      passed: [unit, dev-image]
+    - get: postgres-image
+      params: {format: oci}
+    - get: ci
+  - task: watsjs
+    image: unit-image
+    privileged: true
+    timeout: 1h
+    file: ci/tasks/docker-compose-watsjs.yml
+  on_failure: *failed-concourse
+  on_error: *failed-concourse
+
+- name: upgrade
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [unit, dev-image]
+      trigger: true
+    - get: dev-image
+      passed: [dev-image]
+      params: {format: oci}
+      trigger: true
+    - get: unit-image
+    - get: concourse-image
+      params: {format: oci}
+    - get: postgres-image
+      params: {format: oci}
+    - get: ci
+  - task: upgrade-test
+    privileged: true
+    image: unit-image
+    file: ci/tasks/upgrade-test.yml
+  on_failure: *failed-concourse
+  on_error: *failed-concourse
+
+- name: downgrade
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [unit, dev-image]
+      trigger: true
+    - get: dev-image
+      passed: [dev-image]
+      params: {format: oci}
+      trigger: true
+    - get: unit-image
+    - get: concourse-image
+      params: {format: oci}
+    - get: postgres-image
+      params: {format: oci}
+    - get: ci
+  - task: downgrade-test
+    privileged: true
+    image: unit-image
+    file: ci/tasks/downgrade-test.yml
+
+- name: k8s-check-helm-params
+  public: true
+  max_in_flight: 1
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [build-rc-image]
+      trigger: true
+    - get: concourse-rc-image
+      passed: [build-rc-image]
+      trigger: true
+    - get: concourse-rc-image-ubuntu
+      passed: [build-rc-image]
+      trigger: true
+    - get: version
+      passed: [build-rc-image]
+      trigger: true
+    - get: unit-image
+    - get: concourse-chart
+      trigger: true
+    - get: linux-rc-ubuntu
+      passed: [bin-smoke]
+      trigger: true
+    - get: ci
+  - task: check-params
+    file: ci/tasks/check-distribution-env.yml
+    image: unit-image
+    input_mapping: {distribution: concourse-chart, linux-rc: linux-rc-ubuntu}
+    params: {DISTRIBUTION: helm}
+  on_failure: *failed-concourse
+  on_error: *failed-concourse
+
+- name: k8s-smoke
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [build-rc-image]
+      trigger: true
+    - get: concourse-rc-image
+      passed: [build-rc-image]
+      params: {format: oci}
+      trigger: true
+    - get: concourse-rc-image-ubuntu
+      passed: [build-rc-image]
+      params: {format: oci}
+      trigger: true
+    - get: version
+      passed: [build-rc-image]
+      trigger: true
+    - get: concourse-chart
+    - get: unit-image
+      passed: [build-rc-image]
+    - get: ci
+  - try:
+      task: try-delete
+      image: unit-image
+      file: ci/tasks/k8s-delete.yml
+      params:
+        KUBE_CONFIG: ((kube_config))
+        RELEASE_NAME: ((concourse_smoke_deployment_name))
+        CONCOURSE_IMAGE: concourse/concourse-rc
+  - task: deploy
+    image: unit-image
+    input_mapping: {image-info: concourse-rc-image}
+    file: ci/tasks/k8s-deploy.yml
+    params:
+      KUBE_CONFIG: ((kube_config))
+      RELEASE_NAME: ((concourse_smoke_deployment_name))
+      CONCOURSE_IMAGE: concourse/concourse-rc
+  - task: k8s-smoke
+    image: unit-image
+    file: ci/tasks/k8s-smoke.yml
+    params:
+      KUBE_CONFIG: ((kube_config))
+      RELEASE_NAME: ((concourse_smoke_deployment_name))
+      MAX_TICKS: 180
+  - task: delete
+    image: unit-image
+    file: ci/tasks/k8s-delete.yml
+    params:
+      KUBE_CONFIG: ((kube_config))
+      RELEASE_NAME: ((concourse_smoke_deployment_name))
+      CONCOURSE_IMAGE: concourse/concourse-rc
+  on_failure: *failed-concourse
+  on_error: *failed-concourse
+
+- name: k8s-topgun
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [k8s-smoke]
+      trigger: true
+      tags: [k8s-topgun]
+    - get: version
+      passed: [k8s-smoke]
+      trigger: true
+      tags: [k8s-topgun]
+    - get: concourse-rc-image
+      passed: [k8s-smoke]
+      trigger: true
+      params: {format: oci}
+      tags: [k8s-topgun]
+    - get: concourse-rc-image-ubuntu
+      passed: [k8s-smoke]
+      trigger: true
+      params: {format: oci}
+      tags: [k8s-topgun]
+    - get: unit-image
+      tags: [k8s-topgun]
+    - get: helm-charts
+      tags: [k8s-topgun]
+    - get: concourse-chart
+      trigger: true
+      passed: [k8s-smoke]
+      tags: [k8s-topgun]
+    - get: ci
+      tags: [k8s-topgun]
+  - task: k8s-topgun
+    file: ci/tasks/k8s-topgun.yml
+    image: unit-image
+    tags: [k8s-topgun]
+    params:
+      IN_CLUSTER: "true"
+      KUBE_CONFIG: ((kube_config))
+      CONCOURSE_IMAGE_NAME: concourse/concourse-rc
+  on_failure: *failed-concourse
+  on_error: *failed-concourse
+
+- name: rc
+  public: true
+  serial_groups: [version]
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [testflight, watsjs, upgrade, downgrade]
+      trigger: true
+    - get: dev-image
+      trigger: true
+      passed: [testflight, watsjs, upgrade, downgrade]
+    - get: unit-image
+      passed: [testflight, watsjs, upgrade, downgrade]
+      trigger: true
+  - put: version
+    params: {pre: rc}
+
+- name: build-rc
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [rc]
+      trigger: true
+    - get: unit-image
+    - get: version
+      passed: [rc]
+      trigger: true
+    - get: final-version
+      resource: version
+      passed: [rc]
+      params: {bump: final}
+    - get: gdn
+      trigger: true
+    - get: ci
+    - get: resource-types-alpine-image
+      passed: [resource-types-images]
+    - get: resource-types-ubuntu-image
+      passed: [resource-types-images]
+  - in_parallel:
+    - task: fly-linux
+      file: ci/tasks/fly-build-linux.yml
+    - task: fly-windows
+      file: ci/tasks/fly-build-windows.yml
+    - task: fly-darwin
+      file: ci/tasks/fly-build-darwin.yml
+  - in_parallel:
+      fail_fast: true
+      steps:
+        - task: hoist-resource-types-alpine
+          file: ci/tasks/hoist-linux-dependencies.yml
+          image: resource-types-alpine-image
+          output_mapping: {resource-types: resource-types-alpine}
+        - task: hoist-resource-types-ubuntu
+          file: ci/tasks/hoist-linux-dependencies.yml
+          image: resource-types-ubuntu-image
+          output_mapping: {resource-types: resource-types-ubuntu}
+        - task: yarn-build
+          file: ci/tasks/yarn-build.yml
+          image: unit-image
+  - in_parallel:
+      fail_fast: true
+      steps:
+      - task: concourse-linux-alpine
+        file: ci/tasks/concourse-build-linux.yml
+        image: unit-image
+        input_mapping: {concourse: built-concourse, resource-types: resource-types-alpine}
+        output_mapping: {concourse-tarball: concourse-linux-alpine}
+      - task: concourse-linux-ubuntu
+        image: unit-image
+        file: ci/tasks/concourse-build-linux.yml
+        input_mapping: {concourse: built-concourse, resource-types: resource-types-ubuntu}
+        output_mapping: {concourse-tarball: concourse-linux-ubuntu}
+      - task: concourse-windows
+        file: ci/tasks/concourse-build-windows.yml
+        input_mapping: {concourse: built-concourse}
+      - task: concourse-darwin
+        file: ci/tasks/concourse-build-darwin.yml
+        output_mapping: {concourse-tarball: concourse-darwin}
+  - in_parallel:
+    - put: linux-rc
+      params: {file: concourse-linux-alpine/concourse-*.tgz}
+      inputs: [concourse-linux-alpine]
+    - put: linux-rc-ubuntu
+      params: {file: concourse-linux-ubuntu/concourse-*.tgz}
+      inputs: [concourse-linux-ubuntu]
+    - put: windows-rc
+      params: {file: concourse-windows/concourse-*.zip}
+      inputs: [concourse-windows]
+    - put: darwin-rc
+      params: {file: concourse-darwin/concourse-*.tgz}
+      inputs: [concourse-darwin]
+
+- name: build-rc-image
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [build-rc]
+      trigger: true
+    - get: unit-image
+    - get: version
+      passed: [build-rc]
+      trigger: true
+    - get: linux-rc
+      trigger: true
+      passed: [build-rc]
+    - get: linux-rc-ubuntu
+      trigger: true
+      passed: [build-rc]
+    - get: concourse-docker
+      trigger: true
+    - get: builder
+    - get: ci
+  - in_parallel:
+      fail_fast: true
+      steps:
+        - task: build-alpine
+          file: concourse-docker/ci/build-image.yml
+          image: builder
+          output_mapping: {image: image-alpine}
+          privileged: true
+        - task: build-ubuntu
+          file: concourse-docker/ci/build-image.yml
+          image: builder
+          input_mapping: {linux-rc: linux-rc-ubuntu}
+          output_mapping: {image: image-ubuntu}
+          privileged: true
+  - in_parallel:
+      fail_fast: true
+      steps:
+        - put: concourse-rc-image
+          inputs: [image-alpine, version]
+          params:
+            image: image-alpine/image.tar
+            additional_tags: version/version
+        - put: concourse-rc-image-ubuntu
+          inputs: [image-ubuntu, version]
+          params:
+            image: image-ubuntu/image.tar
+            additional_tags: version/version
+  on_failure: *failed-concourse
+  on_error: *failed-concourse
+
+- name: bin-smoke
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [build-rc]
+      trigger: true
+    - get: version
+      passed: [build-rc]
+      trigger: true
+    - get: linux-rc-ubuntu
+      passed: [build-rc]
+      trigger: true
+    - get: unit-image
+    - get: ci
+  - task: terraform-smoke
+    image: unit-image
+    file: ci/tasks/terraform-smoke.yml
+    input_mapping: {linux-rc: linux-rc-ubuntu}
+    params:
+      GCP_PROJECT: cf-concourse-production
+      GCP_KEY: ((concourse_smoke_gcp_key))
+      SSH_KEY: ((concourse_smoke_ssh_key))
+      WORKSPACE: release-((release_minor))
+      USE_HTTPS: ((bin_smoke_use_https))
+  - task: smoke
+    image: unit-image
+    file: ci/tasks/smoke.yml
+    input_mapping: {endpoint-info: outputs}
+  on_failure: *failed-concourse
+  on_error: *failed-concourse
+
+- name: bosh-check-props
+  public: true
+  max_in_flight: 1
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [bin-smoke]
+      trigger: true
+    - get: unit-image
+    - get: version
+      passed: [bin-smoke]
+      trigger: true
+    - get: linux-rc-ubuntu
+      passed: [bin-smoke]
+      trigger: true
+    - get: concourse-release-repo
+      trigger: true
+    - get: ci
+  - task: check-props
+    file: ci/tasks/check-distribution-env.yml
+    image: unit-image
+    input_mapping: {distribution: concourse-release-repo, linux-rc: linux-rc-ubuntu}
+    params: {DISTRIBUTION: bosh}
+
+- name: bosh-bump
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [build-rc]
+      trigger: true
+    - get: unit-image
+    - get: version
+      passed: [build-rc]
+      trigger: true
+    - get: linux-rc-ubuntu
+      passed: [build-rc]
+      trigger: true
+    - get: windows-rc
+      passed: [build-rc]
+      trigger: true
+    - get: concourse-release-repo
+    - get: ci
+  - task: bump-concourse-blobs
+    file: ci/tasks/bump-concourse-blobs.yml
+    image: unit-image
+    input_mapping: { linux-rc: linux-rc-ubuntu }
+    params: {GCP_JSON_KEY: ((concourse_artifacts_json_key))}
+  - put: concourse-release-repo
+    params: {repository: bumped-concourse-release-repo}
+
+- name: bosh-smoke
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    # these don't trigger, to ensure that the job gets triggered by
+    # concourse-release, which is unfortunately decoupled from the resource
+    # that we 'put' to.
+    - get: concourse
+      passed: [bosh-bump]
+    - get: unit-image
+      passed: [bosh-bump]
+    - get: version
+      passed: [bosh-bump]
+    - get: concourse-release
+      trigger: true
+    - get: postgres-release
+      trigger: true
+    - get: bpm-release
+      trigger: true
+    - get: gcp-xenial-stemcell
+      trigger: true
+    - get: ci
+  - put: smoke-deployment
+    tags: [bosh]
+    params:
+      manifest: ci/deployments/bosh-smoke.yml
+      releases:
+      - concourse-release/*.tgz
+      - postgres-release/*.tgz
+      - bpm-release/*.tgz
+      stemcells:
+      - gcp-xenial-stemcell/*.tgz
+      vars:
+        deployment_name: ((concourse_smoke_deployment_name))
+  - task: discover-bosh-endpoint-info
+    tags: [bosh]
+    file: ci/tasks/discover-bosh-endpoint-info.yml
+    image: unit-image
+    params:
+      BOSH_ENVIRONMENT: https://10.0.0.6:25555
+      BOSH_CA_CERT: ((testing_bosh_ca_cert))
+      BOSH_CLIENT: ((testing_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((testing_bosh_client.secret))
+      BOSH_DEPLOYMENT: ((concourse_smoke_deployment_name))
+      BOSH_INSTANCE_GROUP: concourse
+  - task: smoke
+    tags: [bosh]
+    image: unit-image
+    file: ci/tasks/smoke.yml
+  on_failure: *failed-concourse
+  on_error: *failed-concourse
+
+- name: bosh-topgun
+  public: true
+  serial: true
+  interruptible: true
+  plan:
+  - in_parallel:
+    # these don't trigger, to ensure that the job gets triggered by
+    # concourse-release, which is unfortunately decoupled from the resource
+    # that we 'put' to.
+    - get: concourse
+      passed: [bosh-bump]
+    - get: unit-image
+      passed: [bosh-bump]
+    - get: version
+      passed: [bosh-bump]
+    - get: concourse-release
+      trigger: true
+    - get: postgres-release
+      trigger: true
+    - get: bpm-release
+      trigger: true
+    - get: bbr-sdk-release
+      trigger: true
+    - get: gcp-xenial-stemcell
+      trigger: true
+    - get: vault-release
+      trigger: true
+    - get: credhub-release
+      trigger: true
+    - get: uaa-release
+      trigger: true
+    - get: bbr
+      trigger: true
+    - get: ci
+  - task: bosh-topgun
+    tags: [bosh]
+    file: ci/tasks/topgun.yml
+    image: unit-image
+    input_mapping:
+      stemcell: gcp-xenial-stemcell
+    params:
+      DEPLOYMENT_NAME_PREFIX: concourse-topgun-((release_minor))
+      BOSH_ENVIRONMENT: https://10.0.0.6:25555
+      BOSH_CA_CERT: ((testing_bosh_ca_cert))
+      BOSH_CLIENT: ((testing_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((testing_bosh_client.secret))
+      AWS_REGION: ((topgun_aws_ssm.region))
+      AWS_ACCESS_KEY_ID: ((topgun_aws_ssm.access_key_id))
+      AWS_SECRET_ACCESS_KEY: ((topgun_aws_ssm.secret_access_key))
+      SKIP_PACKAGES: "k8s"
+  on_failure: *failed-concourse
+  on_error: *failed-concourse
+
+- name: shipit
+  public: true
+  serial_groups: [version]
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed:
+      - build-rc
+      - bosh-smoke
+      - bosh-topgun
+      - bosh-check-props
+    - get: unit-image
+      passed:
+      - build-rc
+      - bosh-smoke
+      - bosh-topgun
+    - get: final-version
+      resource: version
+      params: {bump: final}
+      passed:
+      - build-rc
+      - bosh-smoke
+      - bosh-topgun
+      - bosh-check-props
+    - get: linux-rc
+      passed: [build-rc]
+    - get: linux-rc-ubuntu
+      passed: [build-rc, bosh-check-props]
+    - get: windows-rc
+      passed: [build-rc]
+    - get: darwin-rc
+      passed: [build-rc]
+    - get: concourse-rc-image
+      passed: [k8s-smoke]
+    - get: concourse-rc-image-ubuntu
+    - get: concourse-release
+      passed: [bosh-smoke, bosh-topgun]
+    - get: bpm-release
+      passed: [bosh-smoke, bosh-topgun]
+    - get: postgres-release
+      passed: [bosh-smoke, bosh-topgun]
+  - put: version
+    params: {file: final-version/version}
+
+- name: publish-binaries
+  serial: true
+  plan:
+  - in_parallel:
+    - get: version
+      passed: [shipit]
+      trigger: true
+    - get: concourse
+      passed: [shipit]
+    - get: unit-image
+      passed: [shipit]
+    - get: linux-rc
+      passed: [shipit]
+    - get: windows-rc
+      passed: [shipit]
+    - get: darwin-rc
+      passed: [shipit]
+    - get: ci
+    - get: release-notes
+  - in_parallel:
+    - task: prep-release-assets
+      file: ci/tasks/prep-release-assets.yml
+      image: unit-image
+    - task: build-release-notes
+      file: ci/tasks/build-release-notes.yml
+      image: unit-image
+      params:
+        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
+  - put: concourse-github-release
+    params:
+      commitish: concourse/.git/ref
+      tag: version/version
+      tag_prefix: v
+      name: built-notes/release-name
+      body: built-notes/notes.md
+      globs:
+      - concourse-linux/concourse-*.tgz
+      - concourse-windows/concourse-*.zip
+      - concourse-darwin/concourse-*.tgz
+      - fly-linux/fly-*.tgz
+      - fly-windows/fly-*.zip
+      - fly-darwin/fly-*.tgz
+      - concourse-linux/*.sha1
+      - concourse-windows/*.sha1
+      - concourse-darwin/*.sha1
+      - fly-linux/*.sha1
+      - fly-windows/*.sha1
+      - fly-darwin/*.sha1
+
+- name: publish-bosh-release
+  serial: true
+  plan:
+  - in_parallel:
+    - get: version
+      passed: [shipit]
+      trigger: true
+    - get: concourse-release
+      passed: [shipit]
+  - put: concourse-release-final
+    params:
+      tarball: concourse-release/*.tgz
+      version: version/version
+
+- name: bump-cbd-versions
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse-boshio
+      trigger: true
+    - get: unit-image
+      passed: [shipit]
+    - get: cbd
+    - get: version
+      passed: [shipit]
+    - get: bpm-release
+      passed: [shipit]
+    - get: postgres-release
+      passed: [shipit]
+  - task: bump-versions
+    file: cbd/ci/bump-versions.yml
+    input_mapping: {concourse-bosh-deployment: cbd}
+    image: unit-image
+  - put: cbd
+    params:
+      repository: bumped-repo
+      merge: true
+
+- name: publish-image
+  serial: true
+  plan:
+  - in_parallel:
+    - get: version
+      passed: [shipit]
+      trigger: true
+    - get: concourse
+      passed: [shipit]
+    - get: concourse-rc-image
+      passed: [shipit]
+      params: {format: oci}
+    - get: concourse-rc-image-ubuntu
+      passed: [shipit]
+      params: {format: oci}
+    - get: concourse-rc-image-ubuntu-rootfs
+      resource: concourse-rc-image-ubuntu
+      passed: [shipit]
+    - get: latest-version
+    - get: latest-of-same-major-version
+    - get: ci
+  - in_parallel:
+    - do:
+      - task: docker-semver-tags
+        file: ci/tasks/docker-semver-tags.yml
+        output_mapping: {tags: alpine-tags}
+
+      - put: concourse-image
+        inputs: [concourse-rc-image, alpine-tags]
+        params:
+          image: concourse-rc-image/image.tar
+          additional_tags: alpine-tags/tags
+
+    - do:
+      - task: docker-semver-tags
+        file: ci/tasks/docker-semver-tags.yml
+        output_mapping: {tags: ubuntu-tags}
+        params: {SUFFIX: ubuntu}
+
+      - task: generate-dpkg-list
+        file: ci/tasks/generate-dpkg-list.yml
+        image: concourse-rc-image-ubuntu-rootfs
+        params: {COMPONENT_NAME: "concourse"}
+
+      - put: concourse-image-dpkg-list
+        inputs: [dpkg-list]
+        params: {file: "dpkg-list/concourse-*.txt"}
+
+      - put: concourse-image-ubuntu
+        inputs: [concourse-rc-image-ubuntu, ubuntu-tags]
+        params:
+          image: concourse-rc-image-ubuntu/image.tar
+          additional_tags: ubuntu-tags/tags
+
+- name: publish-docs
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse-github-release
+      passed: [publish-binaries]
+      trigger: true
+    - get: docs
+  - task: build-docs
+    file: docs/ci/build.yml
+    params:
+      ANALYTICS_ID: ((analytics_id))
+      GITHUB_TOKEN: ((concourse_github_dummy.access_token))
+  - put: docs-gh-pages
+    params: {repository: built-docs}
+
+- name: ship-chart
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse-version
+      resource: version
+      passed: [shipit]
+    - get: concourse-chart
+      passed: [k8s-topgun]
+    - get: unit-image
+      passed: [k8s-topgun]
+    - get: final-chart-version
+      resource: chart-version
+      params: {bump: final}
+  - put: chart-version
+    params: {file: final-chart-version/version}
+
+- name: publish-chart
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: chart-version
+      passed: [ship-chart]
+      trigger: true
+    - get: concourse-version
+      resource: version
+      passed: [ship-chart]
+    - get: concourse-chart
+      passed: [ship-chart]
+    - get: unit-image
+      passed: [ship-chart]
+    - get: chart-repo-index
+    - get: ci
+  - task: build-chart
+    image: unit-image
+    file: ci/tasks/package-chart.yml
+  - in_parallel:
+    - put: chart-repo-index
+      inputs: [packaged-chart]
+      params:
+        file: packaged-chart/index.yaml
+    - put: chart-repo
+      inputs: [packaged-chart]
+      params:
+        file: packaged-chart/concourse-*.tgz
+    - put: concourse-chart
+      inputs: [concourse]
+      params:
+        repository: concourse
+        merge: true
+
+- name: patch
+  public: true
+  serial_groups: [version]
+  plan:
+  - get: version
+    passed: [shipit]
+    trigger: true
+    params:
+      bump: patch
+      pre: rc
+  - put: version
+    params:
+      file: version/version
+
+- name: chart-patch
+  public: true
+  serial_groups: [chart-version]
+  plan:
+  - put: chart-version
+    params: {bump: patch, pre: rc}
+
+resources:
+- name: concourse
+  type: git
+  icon: &git-icon github-circle
+  source:
+    uri: https://github.com/concourse/concourse.git
+    branch: release/((release_minor)).x
+    ignore_paths:
+    - release-notes/
+
+- name: ci
+  type: git
+  icon: *git-icon
+  source:
+    uri: https://github.com/concourse/ci.git
+    branch: master
+
+- name: release-notes
+  type: git
+  icon: *git-icon
+  source:
+    uri: https://github.com/concourse/concourse.git
+    branch: release/((release_minor)).x
+    paths:
+    - release-notes/
+
+- name: concourse-docker
+  type: git
+  icon: &git-icon github-circle
+  source:
+    uri: https://github.com/concourse/concourse-docker.git
+    branch: master
+
+- name: notify
+  type: slack-notifier
+  icon: slack
+  source:
+    url: ((slack_hook))
+    username: ((basic_auth.username))
+    password: ((basic_auth.password))
+    concourse_url: https://ci.concourse-ci.org
+
+- name: resource-types-alpine-image
+  type: registry-image
+  icon: &image-icon docker
+  source:
+    repository: concourse/resource-types
+    tag: release-((release_minor))
+    username: ((docker.username))
+    password: ((docker.password))
+
+
+- name: resource-types-ubuntu-image
+  type: registry-image
+  icon: &image-icon docker
+  source:
+    repository: concourse/resource-types
+    tag: release-((release_minor))-ubuntu
+    username: ((docker.username))
+    password: ((docker.password))
+
+- name: dev-image
+  type: registry-image
+  icon: *image-icon
+  source:
+    repository: concourse/dev
+    username: ((docker.username))
+    password: ((docker.password))
+    tag: release-((release_minor))
+
+- name: concourse-rc-image
+  type: registry-image
+  icon: *image-icon
+  source:
+    repository: concourse/concourse-rc
+    username: ((docker.username))
+    password: ((docker.password))
+    tag: release-((release_minor))
+
+- name: concourse-rc-image-ubuntu
+  type: registry-image
+  icon: *image-icon
+  source:
+    repository: concourse/concourse-rc
+    username: ((docker.username))
+    password: ((docker.password))
+    tag: release-((release_minor))-ubuntu
+
+- name: concourse-image
+  type: registry-image
+  icon: *image-icon
+  source:
+    repository: concourse/concourse
+    username: ((docker.username))
+    password: ((docker.password))
+
+    # avoid tagging as 'latest' in case this is a patch release for an older
+    # version
+    tag: ((latest_release))
+
+- name: concourse-image-ubuntu
+  type: registry-image
+  icon: *image-icon
+  source:
+    repository: concourse/concourse
+    username: ((docker.username))
+    password: ((docker.password))
+
+    # avoid tagging as 'latest' in case this is a patch release for an older
+    # version
+    tag: ((release_minor))-ubuntu
+
+- name: version
+  type: semver
+  icon: tag
+  source:
+    driver: gcs
+    json_key: ((concourse_artifacts_json_key))
+
+    bucket: concourse-artifacts
+    key: version-((release_minor))
+    initial_version: ((release_minor)).1-rc.0
+
+- name: latest-version
+  type: github-release
+  icon: &release-icon package-variant-closed
+  source:
+    owner: concourse
+    repository: concourse
+    access_token: ((concourse_github_release.access_token))
+
+- name: latest-of-same-major-version
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: concourse
+    access_token: ((concourse_github_release.access_token))
+    tag_filter: '^v(((release_major))\.\d+\.\d+)$'
+
+- name: linux-rc
+  type: gcs
+  icon: linux
+  source:
+    bucket: concourse-artifacts
+    json_key: ((concourse_artifacts_json_key))
+    regexp: rcs/concourse-(.*)-linux-amd64.tgz
+
+- name: linux-rc-ubuntu
+  type: gcs
+  icon: linux
+  source:
+    bucket: concourse-artifacts
+    json_key: ((concourse_artifacts_json_key))
+    regexp: rcs/concourse-(.*)-linux-ubuntu-amd64.tgz
+
+- name: windows-rc
+  type: gcs
+  icon: windows
+  source:
+    bucket: concourse-artifacts
+    json_key: ((concourse_artifacts_json_key))
+    regexp: rcs/concourse-(.*)-windows-amd64.zip
+
+- name: darwin-rc
+  type: gcs
+  icon: apple
+  source:
+    bucket: concourse-artifacts
+    json_key: ((concourse_artifacts_json_key))
+    regexp: rcs/concourse-(.*)-darwin-amd64.tgz
+
+- name: docs
+  type: git
+  icon: *git-icon
+  source:
+    uri: https://github.com/concourse/docs
+    branch: master
+
+- name: docs-gh-pages
+  type: git
+  icon: *git-icon
+  source:
+    uri: git@github.com:concourse/docs
+    branch: gh-pages
+    private_key: ((docs_deploy_key))
+
+- name: concourse-release
+  type: bosh-release
+  icon: *release-icon
+  source:
+    uri: https://github.com/concourse/concourse-bosh-release
+    branch: release/((release_minor)).x
+    dev_releases: true
+    private_config: &release_private_config
+      blobstore:
+        provider: gcs
+        options:
+          credentials_source: static
+          json_key: ((concourse_artifacts_json_key))
+
+- name: concourse-release-final
+  type: bosh-release
+  icon: *release-icon
+  source:
+    uri: git@github.com:concourse/concourse-bosh-release
+    branch: master
+    private_config: *release_private_config
+    private_key: ((concourse_release_deploy_key))
+
+- name: concourse-release-repo
+  type: git
+  icon: *git-icon
+  source:
+    uri: git@github.com:concourse/concourse-bosh-release
+    branch: release/((release_minor)).x
+    private_key: ((concourse_release_deploy_key))
+
+- name: smoke-deployment
+  tags: [bosh]
+  type: bosh-deployment
+  icon: fire
+  source:
+    target: https://10.0.0.6:25555
+    client: ((testing_bosh_client.id))
+    client_secret: ((testing_bosh_client.secret))
+    ca_cert: ((testing_bosh_ca_cert))
+    deployment: ((concourse_smoke_deployment_name))
+
+- name: concourse-chart
+  type: git
+  icon: *git-icon
+  source:
+    uri: git@github.com:concourse/concourse-chart.git
+    branch: release/((release_minor)).x
+    private_key: ((concourse_chart_private_key))
+
+- name: helm-charts
+  type: git
+  icon: *git-icon
+  source:
+    uri: https://github.com/helm/charts
+    branch: master
+
+- name: concourse-github-release
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: concourse
+    access_token: ((concourse_github_release.access_token))
+
+- name: concourse-boshio
+  type: bosh-io-release
+  icon: *release-icon
+  source:
+    repository: concourse/concourse-bosh-release
+    regexp: ((release_minor)).*
+
+- name: unit-image
+  type: registry-image
+  icon: *image-icon
+  source: {repository: concourse/unit}
+
+- name: builder
+  type: registry-image
+  icon: *image-icon
+  source: {repository: vito/oci-build-task}
+
+- name: gcp-xenial-stemcell
+  type: bosh-io-stemcell
+  icon: *release-icon
+  source: {name: bosh-google-kvm-ubuntu-xenial-go_agent}
+
+- name: cbd
+  type: git
+  icon: *git-icon
+  source:
+    uri: git@github.com:concourse/concourse-bosh-deployment.git
+    branch: release/((release_minor)).x
+    private_key: ((concourse_deployment_repo_private_key))
+
+- name: postgres-image
+  type: registry-image
+  icon: *image-icon
+  source: {repository: postgres}
+
+- name: dumb-init
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: Yelp
+    repository: dumb-init
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: bbr
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: cloudfoundry-incubator
+    repository: bosh-backup-and-restore
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: gdn
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: cloudfoundry
+    repository: garden-runc-release
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: postgres-release
+  type: bosh-io-release
+  icon: *release-icon
+  source: {repository: cloudfoundry/postgres-release}
+
+- name: bpm-release
+  type: bosh-io-release
+  icon: *release-icon
+  source:
+    repository: cloudfoundry/bpm-release
+
+- name: vault-release
+  type: bosh-io-release
+  icon: *release-icon
+  source:
+    repository: vito/vault-boshrelease
+
+- name: credhub-release
+  type: bosh-io-release
+  icon: *release-icon
+  source: {repository: pivotal-cf/credhub-release}
+
+- name: uaa-release
+  type: bosh-io-release
+  icon: *release-icon
+  source: {repository: cloudfoundry/uaa-release}
+
+- name: bbr-sdk-release
+  type: bosh-io-release
+  icon: *release-icon
+  source:
+    repository: cloudfoundry-incubator/backup-and-restore-sdk-release
+
+- name: mock-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: mock-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: bosh-io-release-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: bosh-io-release-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: bosh-io-stemcell-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: bosh-io-stemcell-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: cf-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: cloudfoundry-community
+    repository: cf-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: docker-image-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: docker-image-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: git-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: git-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: github-release-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: github-release-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: hg-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: hg-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: pool-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: pool-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: registry-image-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: registry-image-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: s3-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: s3-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: semver-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: semver-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: time-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: time-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: tracker-resource
+  type: github-release
+  icon: *release-icon
+  source:
+    owner: concourse
+    repository: tracker-resource
+    access_token: ((concourse_github_dummy.access_token))
+
+- name: concourse-image-dpkg-list
+  type: gcs
+  icon: format-list-bulleted
+  source:
+    bucket: concourse-ubuntu-dpkg-list
+    json_key: ((concourse_dpkg_list_json_key))
+    regexp: "concourse-dpkg-list-(.*).txt"
+
+- name: chart-repo
+  type: gcs
+  source:
+    bucket: concourse-charts
+    json_key: ((concourse_charts_json_key))
+    regexp: concourse-(.*)\.tgz
+
+- name: chart-repo-index
+  type: gcs
+  source:
+    bucket: concourse-charts
+    json_key: ((concourse_charts_json_key))
+    versioned_file: index.yaml
+
+- name: chart-version
+  type: semver
+  icon: tag
+  source:
+    driver: gcs
+    bucket: concourse-artifacts
+    json_key: ((concourse_artifacts_json_key))
+    key: chart-version-((release_minor))
+
+- name: periodic-check
+  type: time
+  source:
+    start: 2AM
+    stop: 3AM
+    interval: 1h

--- a/tasks/build-dev-image-legacy.yml
+++ b/tasks/build-dev-image-legacy.yml
@@ -1,0 +1,28 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/builder}
+
+params:
+  REPOSITORY: concourse/dev
+  DOCKERFILE: ci/dockerfiles/dev/Dockerfile
+
+inputs:
+- name: ci
+- name: dumb-init
+- name: concourse
+- name: gdn
+- name: resource-types-image
+- name: fly-linux
+- name: fly-windows
+- name: fly-darwin
+
+outputs:
+- name: image
+
+caches:
+- path: cache
+
+run: {path: build}

--- a/tasks/build-dev-image-legacy.yml
+++ b/tasks/build-dev-image-legacy.yml
@@ -7,7 +7,7 @@ image_resource:
 
 params:
   REPOSITORY: concourse/dev
-  DOCKERFILE: ci/dockerfiles/dev/Dockerfile
+  DOCKERFILE: ci/dockerfiles/dev-legacy/Dockerfile
 
 inputs:
 - name: ci

--- a/tasks/concourse-build-linux-legacy.yml
+++ b/tasks/concourse-build-linux-legacy.yml
@@ -1,0 +1,34 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/unit}
+
+inputs:
+- name: concourse
+- name: ci
+- name: gdn
+- name: resource-types
+- name: version
+  optional: true
+- name: final-version
+  optional: true
+- name: fly-linux
+  optional: true
+- name: fly-windows
+  optional: true
+- name: fly-darwin
+  optional: true
+
+caches:
+- path: gopath
+
+outputs:
+- name: concourse-tarball
+
+params:
+  PLATFORM: linux
+
+run:
+  path: ci/tasks/scripts/concourse-build

--- a/tasks/concourse-build-linux-legacy.yml
+++ b/tasks/concourse-build-linux-legacy.yml
@@ -31,4 +31,4 @@ params:
   PLATFORM: linux
 
 run:
-  path: ci/tasks/scripts/concourse-build
+  path: ci/tasks/scripts/concourse-build-legacy

--- a/tasks/scripts/concourse-build-legacy
+++ b/tasks/scripts/concourse-build-legacy
@@ -1,0 +1,60 @@
+#!/bin/bash
+# vim: set ft=sh
+
+set -e -x
+
+export GOPATH=$PWD/gopath
+export PATH=$PWD/gopath/bin:$PATH
+
+if [ -z "${PLATFORM}" ]; then
+  echo "usage: PLATFORM=<platform> $0" >&2
+  exit 1
+fi
+
+sha="$(git -C concourse rev-parse HEAD)"
+archive=concourse-${sha}-${PLATFORM}-amd64.tgz
+
+final_version=""
+ldflags=""
+if [ -e final-version/version ]; then
+  final_version="$(cat final-version/version)"
+  ldflags="-X github.com/concourse/concourse.Version=$final_version"
+fi
+
+pushd concourse
+  go install github.com/gobuffalo/packr/packr
+  packr build -o concourse -ldflags "$ldflags" ./cmd/concourse
+
+  if [ -n "$final_version" ]; then
+    test "$(./concourse --version)" = "$final_version"
+  fi
+popd
+
+output=concourse-tarball
+
+mkdir $output/concourse
+
+bin=$output/concourse/bin
+mkdir $bin
+mv concourse/concourse $bin
+[ -d gdn ] && install -m 0755 gdn/gdn* $bin/gdn
+
+if [ "$PLATFORM" = "linux" ]; then
+  # build the init executable for containerd
+  gcc -O2 -static -o $bin/init concourse/cmd/init/init.c
+fi
+
+[ -d resource-types ] && cp -a resource-types $output/concourse
+
+fly_assets=$output/concourse/fly-assets
+mkdir $fly_assets
+[ -d fly-linux ] && cp -a fly-linux/fly-*.tgz $fly_assets
+[ -d fly-windows ] && cp -a fly-windows/fly-*.zip $fly_assets
+[ -d fly-darwin ] && cp -a fly-darwin/fly-*.tgz $fly_assets
+
+pushd $output
+  tar -czf $archive concourse
+  shasum "$archive" > "${archive}.sha1"
+
+  rm -r concourse
+popd

--- a/tasks/scripts/concourse-build-legacy
+++ b/tasks/scripts/concourse-build-legacy
@@ -39,11 +39,6 @@ mkdir $bin
 mv concourse/concourse $bin
 [ -d gdn ] && install -m 0755 gdn/gdn* $bin/gdn
 
-if [ "$PLATFORM" = "linux" ]; then
-  # build the init executable for containerd
-  gcc -O2 -static -o $bin/init concourse/cmd/init/init.c
-fi
-
 [ -d resource-types ] && cp -a resource-types $output/concourse
 
 fly_assets=$output/concourse/fly-assets


### PR DESCRIPTION
Fixes #293 

5.x release [pipelines](https://ci.concourse-ci.org/teams/main/pipelines/release-5.2.x) were failing due to the new dev Docker image requiring containerd dependencies such as runc and containerd itself. This is currently blocking patch releases on the 5.x minors.

This brings up several considerations around how we should separate our Docker files and release pipelines as major dependencies such as containerd, and other runtiimes in the future get added. A comprehensive solution may involve having several layers of Docker images with newer layers adding in the new dependencies, or parameterizing the pipelines to pick up version specific Dockerfiles and tasks.

Since it was taking a while to gauge the full consequences of such approaches, in this PR we opted for a fix that just forks the necessary files for the 5.x releases such that those pipelines use legacy files. The files duplicated are the dev Docker file (`dev-legacy/Dockerfile`), build task (`concourse-build-linux-legacy.yml`), linux build script (`concourse-build-legacy`), and pipeline template file (`release-legacy.yml`).

A test pipeline with the results - https://ci.concourse-ci.org/teams/main/pipelines/release-5.2.x-test.

A parameterized approach is being explored in https://github.com/concourse/ci/pull/294, and might be a better solution.