### PR TITLE
add 5.8.x release pipeline to reconfigure pipeline

### DIFF
--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -168,6 +168,14 @@ jobs:
       latest_release: "5.7"
       concourse_smoke_deployment_name: "concourse-smoke-5-7"
       bin_smoke_use_https: "true"
+  - set_pipeline: release-5.8.x
+      file: pipelines-and-tasks/pipelines/release.yml
+      vars:
+        release_major: "5"
+        release_minor: "5.8"
+        latest_release: "5.8"
+        concourse_smoke_deployment_name: "concourse-smoke-5-8"
+        bin_smoke_use_https: "true"
   - set_pipeline: release-6.0.x
     file: pipelines-and-tasks/pipelines/release.yml
     vars:


### PR DESCRIPTION
The release-5.8.x pipeline was recently created but has not been setup to be reconfigured automatically. This PR fixes that.