### PR TITLE
Fixes issue with yaml indentation in the reconfigure.yml file

### DIFF
--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -169,13 +169,13 @@ jobs:
       concourse_smoke_deployment_name: "concourse-smoke-5-7"
       bin_smoke_use_https: "true"
   - set_pipeline: release-5.8.x
-      file: pipelines-and-tasks/pipelines/release.yml
-      vars:
-        release_major: "5"
-        release_minor: "5.8"
-        latest_release: "5.8"
-        concourse_smoke_deployment_name: "concourse-smoke-5-8"
-        bin_smoke_use_https: "true"
+    file: pipelines-and-tasks/pipelines/release.yml
+    vars:
+      release_major: "5"
+      release_minor: "5.8"
+      latest_release: "5.8"
+      concourse_smoke_deployment_name: "concourse-smoke-5-8"
+      bin_smoke_use_https: "true"
   - set_pipeline: release-6.0.x
     file: pipelines-and-tasks/pipelines/release.yml
     vars:


### PR DESCRIPTION
The section in the reconfigure.yml files that sets the pipeline
`release-5.8.x` was not properly indented.

Solves #298 

Signed-off-by: Izabela Gomes <igomes@pivotal.io>