### PR TITLE
Fixes `discover-component-version` job

### DIFF
--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -69,7 +69,6 @@ groups:
   - bin-smoke
   - upgrade
   - downgrade
-  - discover-component-version
 
 - name: k8s
   jobs:
@@ -96,6 +95,7 @@ groups:
   - publish-chart
   - patch
   - chart-patch
+  - discover-component-version
 
 jobs:
 - name: unit
@@ -862,6 +862,7 @@ jobs:
   serial: true
   plan:
     - in_parallel:
+      - get: ci
       - get: concourse
         passed: [shipit]
         trigger: true


### PR DESCRIPTION
Currently, the jobs `discover-component-version` are in an error state in the release pipelines. Because the git resource `ci` is missing from the job, it cannot find the path to the task file `ci/tasks/discover-component-version.yml`. Also, the job `discover-component-version` was mistakenly placed in `develop` group, instead of in the `publish` group.

In order to solve the issue, the below steps were taken:
- Added get `ci` resource to the job to be able to find the
task file/path
- Placed `discover-component-version` job into the publish
group

Signed-off-by: Izabela Gomes <igomes@pivotal.io>