### PR TITLE
[#286] Add discover-components-version job to master

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -73,6 +73,7 @@ groups:
   - publish-chart
   - pre
   - publish-pre-binaries
+  - discover-component-version
 
 - name: workers
   jobs:
@@ -1180,6 +1181,37 @@ jobs:
   - put: version
     params: {file: final-version/version}
 
+- name: discover-component-version
+  public: true
+  serial: true
+  plan:
+    - in_parallel:
+      - get: ci
+      - get: concourse
+        passed: [shipit]
+        trigger: true
+      - get: unit-image
+        passed: [shipit]
+        trigger: true
+      - get: version
+        passed: [shipit]
+    - task: discover-postgresql-version
+      file: ci/tasks/discover-component-version.yml
+      inputs: [version]
+      output_mapping: {component-version: postgresql-version}
+      params: {COMPONENT_NAME: "postgresql"}
+    - task: discover-helm-version
+      file: ci/tasks/discover-component-version.yml
+      inputs: [version]
+      output_mapping: {component-version: helm-version}
+      params: {COMPONENT_NAME: "helm"}
+    - put: resource-postgresql-version
+      inputs: [postgresql-version]
+      params: {file: "postgresql-version/postgresql-version-*.txt"}
+    - put: resource-helm-version
+      inputs: [helm-version]
+      params: {file: "helm-version/helm-version-*.txt"}
+
 - name: pre
   public: true
   plan:
@@ -2059,6 +2091,22 @@ resources:
     bucket: concourse-ubuntu-dpkg-list
     json_key: ((concourse_dpkg_list_json_key))
     regexp: "concourse-dpkg-list-(.*).txt"
+
+- name: resource-postgresql-version
+  type: gcs
+  icon: format-list-bulleted
+  source:
+    bucket: concourse-components-version
+    json_key: ((concourse_components_json_key))
+    regexp: "postgresql-version-(.*).txt"
+
+- name: resource-helm-version
+  type: gcs
+  icon: format-list-bulleted
+  source:
+    bucket: concourse-components-version
+    json_key: ((concourse_components_json_key))
+    regexp: "helm-version-(.*).txt"
 
 - name: chart-repo
   type: gcs


### PR DESCRIPTION
Same as #288 but for `concourse.yml`

- this job is present in release.yml
- since, a new major version is released from `concourse.yml`, we'd like
  to capture postgres and helm versions for the major as well


Thanks Izabela and Jamie for doing all the work.