### PR TITLE
Chart workflow

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -70,7 +70,6 @@ groups:
   - promote-cbd
   - bump-cbd-versions
   - publish-docs
-  - ship-chart
   - publish-chart
   - pre
   - publish-pre-binaries
@@ -1485,7 +1484,7 @@ jobs:
       repository: cbd-master
       merge: true
 
-- name: ship-chart
+- name: publish-chart
   public: true
   serial: true
   plan:
@@ -1494,23 +1493,9 @@ jobs:
       resource: version
       passed: [shipit]
     - get: concourse-chart
-      passed: [k8s-topgun]
-    - get: unit-image
-      passed: [k8s-topgun]
-
-- name: publish-chart
-  public: true
-  serial: true
-  plan:
-  - in_parallel:
-    - get: concourse-version
-      resource: version
-      passed: [ship-chart]
-    - get: concourse-chart
-      passed: [ship-chart]
+      resource: concourse-chart-master
       trigger: true
     - get: unit-image
-      passed: [ship-chart]
     - get: chart-repo-index
     - get: ci
   - task: build-chart
@@ -1979,6 +1964,14 @@ resources:
     uri: https://github.com/concourse/concourse-docker
 
 - name: concourse-chart
+  type: git
+  icon: *git-icon
+  source:
+    uri: git@github.com:concourse/concourse-chart.git
+    branch: dev
+    private_key: ((concourse_chart_private_key))
+
+- name: concourse-chart-master
   type: git
   icon: *git-icon
   source:

--- a/pipelines/helm-prs.yml
+++ b/pipelines/helm-prs.yml
@@ -27,6 +27,13 @@ resources:
     uri: https://github.com/concourse/concourse.git
     branch: ((concourse_base_branch))
 
+- name: concourse-chart
+  type: git
+  icon: github-circle
+  source:
+    uri: git@github.com:concourse/concourse-chart.git
+    branch: master
+
 - name: ci
   type: git
   icon: github-circle
@@ -120,6 +127,7 @@ jobs:
       tags: [k8s-topgun]
     - get: unit-image
       tags: [k8s-topgun]
+    - get: concourse-chart
   - put: update-pr-status
     resource: chart-pr
     inputs: [chart-pr]

--- a/tasks/k8s-version-bump-check.yml
+++ b/tasks/k8s-version-bump-check.yml
@@ -1,13 +1,19 @@
 ---
 platform: linux
 
+image_resource:
+  type: registry-image
+  source: {repository: golang}
+
 inputs:
 - name: chart-pr
+- name: concourse-chart
+- name: ci
 
 run:
   path: bash
   args:
   - -cex
   - |
-    cd chart-pr
-    git diff master HEAD -- Chart.yaml | egrep '\+version: [0-9]+\.[0-9]+\.[0-9]+'
+    go get -d -v ./...
+    go run ci/tasks/scripts/k8s-version-bump-check.go

--- a/tasks/scripts/k8s-version-bump-check.go
+++ b/tasks/scripts/k8s-version-bump-check.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/hashicorp/go-version"
+	"sigs.k8s.io/yaml"
+)
+
+type ChartVersion struct {
+	Version string `json:"version"`
+}
+
+func main() {
+	prVersion, err := version.NewVersion(GetChartVersion("chart-pr/Chart.yaml"))
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	latestPublishedVersion, err := version.NewVersion(GetChartVersion("concourse-chart/Chart.yaml"))
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if prVersion.Metadata() != "" || prVersion.Prerelease() != "" {
+		fmt.Println(prVersion.String(), "version cannot contain any metadata or prerelease data")
+		os.Exit(1)
+	}
+
+	if prVersion.GreaterThan(latestPublishedVersion) {
+		fmt.Println(prVersion.String(), "is greater than", latestPublishedVersion.String())
+		os.Exit(0)
+	}
+
+	fmt.Println(prVersion.String(), "is not greater than", latestPublishedVersion.String())
+	fmt.Println("Please bump the version in the Chart.yaml file")
+	os.Exit(1)
+}
+
+func GetChartVersion(chartYaml string) string {
+	data, err := ioutil.ReadFile(chartYaml)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	var chart ChartVersion
+
+	err = yaml.Unmarshal(data, &chart)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	return chart.Version
+}


### PR DESCRIPTION
This PR does the following:

- Removes the `ship-chart` job
- `publish-chart` runs on every commit to `master` of github.com/concourse/concourse-chart
  - Every PR we get in, the person submitting it expects a new version of the chart to be published immediately. This change ensures that happens now.
- Changed the bash script that checked if the chart version had been bumped into a go script. It's easier to understand the go file. It was also easier to add extra checks like ensuring there's no metadata (`+data`) added onto the version
  - There has been discussion on doing the version bumping automatically in the pipeline. The problem with that is a human still needs to decide if it's a major, minor, or patch bump and this becomes annoying to manage since the chart publishes more frequently than Concourse itself. With this check being done on this PR we ensure that the version is always bumped and PR's don't get in that don't bump the version.