### PR TITLE
do not set env vars before generating keys

### DIFF
--- a/dockerfiles/dev/Dockerfile-v6
+++ b/dockerfiles/dev/Dockerfile-v6
@@ -74,15 +74,6 @@ ENV CONCOURSE_WORK_DIR /worker-state
 # enable DNS proxy to support Docker's 127.x.x.x DNS server
 ENV CONCOURSE_GARDEN_DNS_PROXY_ENABLE true
 
-# 'web' keys
-ENV CONCOURSE_SESSION_SIGNING_KEY     /concourse-keys/session_signing_key
-ENV CONCOURSE_TSA_AUTHORIZED_KEYS     /concourse-keys/authorized_worker_keys
-ENV CONCOURSE_TSA_HOST_KEY            /concourse-keys/tsa_host_key
-
-# 'worker' keys
-ENV CONCOURSE_TSA_PUBLIC_KEY          /concourse-keys/tsa_host_key.pub
-ENV CONCOURSE_TSA_WORKER_PRIVATE_KEY  /concourse-keys/worker_key
-
 # set $PATH for convenience
 ENV PATH /usr/local/concourse/bin:${PATH}
 


### PR DESCRIPTION
While it is nice to know that these variables will be set, in all of the cases
where we rely on the dev image as a base we actually generate the keys ourselves
and have the opportunity to set these environment variables at a more sensible
time.

Blocked on concourse/concourse#5491