### PR TITLE
use full semver in RC binary filenames

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -1847,7 +1847,7 @@ resources:
   source:
     bucket: concourse-artifacts
     json_key: ((concourse_artifacts_json_key))
-    regexp: rcs/concourse-(.*)-linux-amd64.tgz
+    regexp: rcs/concourse-(.*).linux.amd64.tgz
 
 - name: linux-rc-ubuntu
   type: gcs
@@ -1855,7 +1855,7 @@ resources:
   source:
     bucket: concourse-artifacts
     json_key: ((concourse_artifacts_json_key))
-    regexp: rcs/concourse-(.*)-linux-ubuntu-amd64.tgz
+    regexp: rcs/concourse-(.*).linux-ubuntu.amd64.tgz
 
 - name: windows-rc
   type: gcs
@@ -1863,7 +1863,7 @@ resources:
   source:
     bucket: concourse-artifacts
     json_key: ((concourse_artifacts_json_key))
-    regexp: rcs/concourse-(.*)-windows-amd64.zip
+    regexp: rcs/concourse-(.*).windows.amd64.zip
 
 - name: darwin-rc
   type: gcs
@@ -1871,7 +1871,7 @@ resources:
   source:
     bucket: concourse-artifacts
     json_key: ((concourse_artifacts_json_key))
-    regexp: rcs/concourse-(.*)-darwin-amd64.tgz
+    regexp: rcs/concourse-(.*).darwin.amd64.tgz
 
 - name: docs
   type: git

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -1227,7 +1227,7 @@ resources:
   source:
     bucket: concourse-artifacts
     json_key: ((concourse_artifacts_json_key))
-    regexp: rcs/concourse-(.*)-linux-amd64.tgz
+    regexp: rcs/concourse-(.*).linux.amd64.tgz
 
 - name: linux-rc-ubuntu
   type: gcs
@@ -1235,7 +1235,7 @@ resources:
   source:
     bucket: concourse-artifacts
     json_key: ((concourse_artifacts_json_key))
-    regexp: rcs/concourse-(.*)-linux-ubuntu-amd64.tgz
+    regexp: rcs/concourse-(.*).linux-ubuntu.amd64.tgz
 
 - name: windows-rc
   type: gcs
@@ -1243,7 +1243,7 @@ resources:
   source:
     bucket: concourse-artifacts
     json_key: ((concourse_artifacts_json_key))
-    regexp: rcs/concourse-(.*)-windows-amd64.zip
+    regexp: rcs/concourse-(.*).windows.amd64.zip
 
 - name: darwin-rc
   type: gcs
@@ -1251,7 +1251,7 @@ resources:
   source:
     bucket: concourse-artifacts
     json_key: ((concourse_artifacts_json_key))
-    regexp: rcs/concourse-(.*)-darwin-amd64.tgz
+    regexp: rcs/concourse-(.*).darwin.amd64.tgz
 
 - name: docs
   type: git

--- a/tasks/concourse-build-linux.yml
+++ b/tasks/concourse-build-linux.yml
@@ -17,7 +17,6 @@ inputs:
   optional: true
 - name: resource-types
 - name: version
-  optional: true
 - name: final-version
   optional: true
 - name: fly-linux

--- a/tasks/concourse-build-windows.yml
+++ b/tasks/concourse-build-windows.yml
@@ -5,7 +5,6 @@ inputs:
 - name: concourse
 - name: ci
 - name: version
-  optional: true
 - name: final-version
   optional: true
 - name: fly-linux

--- a/tasks/scripts/concourse-build
+++ b/tasks/scripts/concourse-build
@@ -11,8 +11,9 @@ if [ -z "${PLATFORM}" ]; then
   exit 1
 fi
 
+version=$(cat version/version)
 sha="$(git -C concourse rev-parse HEAD)"
-archive=concourse-${sha}-${PLATFORM}-amd64.tgz
+archive=concourse-${version}+${sha}.${PLATFORM}.amd64.tgz
 
 final_version=""
 ldflags=""
@@ -39,8 +40,6 @@ mkdir $bin
 mv concourse/concourse $bin
 [ -d gdn ] && install -m 0755 gdn/gdn* $bin/gdn
 
-
-version=$(cat version/version)
 major_version=$(echo $version | cut -d. -f1)
 # Only include containerd and its dependencies for v6 or higher
 if [ $major_version \> "5" ];

--- a/tasks/scripts/concourse-build-windows.ps1
+++ b/tasks/scripts/concourse-build-windows.ps1
@@ -1,7 +1,8 @@
 . .\ci\tasks\scripts\go-build.ps1
 
+$version = (Get-Content "version\version")
 $sha = & git -C concourse rev-parse HEAD
-$archive = "concourse-${sha}-windows-amd64.zip"
+$archive = "concourse-${version}+${sha}.windows.amd64.zip"
 
 # can't figure out how to pass an empty string arg in PowerShell, so just
 # configure a noop for the fallback


### PR DESCRIPTION
Fixes concourse/ci#307.

The new format for an RC binary's filename is

```
concourse-<major>.<minor>.<patch>-rc.<rc>+<commit>.<platform>.amd64.<ext>
```

where `platform` is one of:
* `linux` (where the bundled resource types are based on alpine)
* `linux-ubuntu` (where the bundled resource types are based on ubuntu)
* `darwin`
* `windows`

and ext is `.tgz` except on windows where it is `.zip`.

What's great about this is that it is semver-compliant, so our gcs resources
will properly order their versions, and it gives us an easy way to track which
build produced a given binary.