### PR TITLE
automate uploading bosh release to tanzu network

### DIFF
--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -152,6 +152,7 @@ jobs:
       latest_release: "5.2"
       concourse_smoke_deployment_name: "concourse-smoke-5-2"
       bin_smoke_use_https: "false"
+      end_of_general_support: "2020-04-31"
   - set_pipeline: release-5.5.x
     file: pipelines-and-tasks/pipelines/release.yml
     vars:
@@ -160,6 +161,7 @@ jobs:
       latest_release: "5.5"
       concourse_smoke_deployment_name: "concourse-smoke-5-5"
       bin_smoke_use_https: "true"
+      end_of_general_support: "2020-07-31"
   - set_pipeline: release-5.7.x
     file: pipelines-and-tasks/pipelines/release.yml
     vars:
@@ -168,6 +170,7 @@ jobs:
       latest_release: "5.7"
       concourse_smoke_deployment_name: "concourse-smoke-5-7"
       bin_smoke_use_https: "true"
+      end_of_general_support: "N/A"
   - set_pipeline: release-5.8.x
     file: pipelines-and-tasks/pipelines/release.yml
     vars:
@@ -176,6 +179,7 @@ jobs:
       latest_release: "5.8"
       concourse_smoke_deployment_name: "concourse-smoke-5-8"
       bin_smoke_use_https: "true"
+      end_of_general_support: "N/A"
   - set_pipeline: release-6.0.x
     file: pipelines-and-tasks/pipelines/release-v6.yml
     vars:

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -977,6 +977,8 @@ jobs:
       passed: [publish-bosh-release]
   - task: create-pivnet-metadata
     file: ci/tasks/create-pivnet-metadata.yml
+    params:
+      END_OF_GENERAL_SUPPORT: ((end_of_general_support))
   - in_parallel:
     - put: pivnet-bosh-release
       inputs:

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -5,6 +5,7 @@
 #                                       concourse matches the desired release version
 #   ((concourse_smoke_deployment_name)) a unique name for the smoke bosh deployment
 #   ((latest_release))                  the latest concourse/concourse tag for upgrade testing (choose this based on the patch release eg 5.5 for 5.5.x)
+#   ((end_of_general_support))          YYYY-MM-dd format when support for this minor line ends
 #
 # the following git branches need to be created:
 #
@@ -29,6 +30,12 @@ resource_types:
 - name: slack-notifier
   type: registry-image
   source: {repository: mockersf/concourse-slack-notifier}
+
+- name: pivnet
+  type: registry-image
+  source:
+    repository: pivotalcf/pivnet-resource
+    tag: latest-final
 
 groups:
 - name: develop
@@ -64,6 +71,7 @@ groups:
   - publish-binaries
   - publish-image
   - publish-bosh-release
+  - publish-pivnet-bosh
   - bump-cbd-versions
   - publish-docs
   - ship-chart
@@ -831,6 +839,8 @@ jobs:
       passed: [bosh-smoke, bosh-topgun]
     - get: postgres-release
       passed: [bosh-smoke, bosh-topgun]
+    - get: gcp-xenial-stemcell
+      passed: [bosh-smoke, bosh-topgun]
   - put: version
     params: {file: final-version/version}
 
@@ -923,6 +933,8 @@ jobs:
       trigger: true
     - get: concourse-release
       passed: [shipit]
+    - get: gcp-xenial-stemcell
+      passed: [shipit]
   - put: concourse-release-final
     params:
       tarball: concourse-release/*.tgz
@@ -951,6 +963,28 @@ jobs:
     params:
       repository: bumped-repo
       merge: true
+
+- name: publish-pivnet-bosh
+  plan:
+  - in_parallel:
+    - get: ci
+    - get: concourse-release-final
+      passed: [publish-bosh-release]
+      trigger: true
+    - get: version
+      passed: [publish-bosh-release]
+    - get: gcp-xenial-stemcell
+      passed: [publish-bosh-release]
+  - task: create-pivnet-metadata
+    file: ci/tasks/create-pivnet-metadata.yml
+  - in_parallel:
+    - put: pivnet-bosh-release
+      inputs:
+        - concourse-release-final
+        - product
+      params:
+        metadata_file: product/metadata.yaml
+        file_glob: concourse-release-final/concourse-*.tgz
 
 - name: publish-image
   serial: true
@@ -1340,6 +1374,15 @@ resources:
   source:
     repository: concourse/concourse-bosh-release
     regexp: ((release_minor)).*
+
+- name: pivnet-bosh-release
+  type: pivnet
+  icon: chart-timeline-variant
+  source:
+    api_token: ((pivnet-token))
+    product_slug: p-concourse
+    copy_metadata: true
+    endpoint: https://network.pivotal.io
 
 - name: unit-image
   type: registry-image

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -1382,7 +1382,6 @@ resources:
     api_token: ((pivnet-token))
     product_slug: p-concourse
     copy_metadata: true
-    endpoint: https://network.pivotal.io
 
 - name: unit-image
   type: registry-image

--- a/tasks/create-pivnet-metadata.yml
+++ b/tasks/create-pivnet-metadata.yml
@@ -1,0 +1,13 @@
+platform: linux
+inputs:
+- name: ci
+- name: concourse-release-final
+- name: gcp-xenial-stemcell
+- name: version
+outputs:
+- name: product
+image_resource:
+  type: registry-image
+  source: { repository: ubuntu }
+run:
+  path: ci/tasks/scripts/create-pivnet-metadata

--- a/tasks/create-pivnet-metadata.yml
+++ b/tasks/create-pivnet-metadata.yml
@@ -9,5 +9,7 @@ outputs:
 image_resource:
   type: registry-image
   source: { repository: ubuntu }
+params:
+  END_OF_GENERAL_SUPPORT:
 run:
   path: ci/tasks/scripts/create-pivnet-metadata

--- a/tasks/scripts/create-pivnet-metadata
+++ b/tasks/scripts/create-pivnet-metadata
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+echo "release:
+  version: $(echo $(cat version/version) BOSH Deployment | head -c 26)
+  release_type: Developer Release
+  eula_slug: pivotal_software_eula
+  description: |
+    Concourse for VMware Tanzu v$(cat version/version) is a stable and VMware supported version of Concourse. Please refer to Release Notes for breaking changes, features and fixes in this release.
+    
+    Concourse for VMware Tanzu v$(cat version/version) was tested on Stemcell $(cat gcp-xenial-stemcell/version) (Xenial) upon release and supports the 621.* Stemcell family
+    
+    Concourse for VMware Tanzu v$(cat version/version) requires PostgreSQL 9.5+ 
+  release_notes_url: https://docs.pivotal.io/p-concourse/v5/rn/
+  availability: Admins Only
+  end_of_support_date: ((end_of_general_support))
+product_files:
+- file: $(ls concourse-release-final/concourse-*.tgz)
+  upload_as: Concourse BOSH $(cat version/version)
+" > product/metadata.yaml

--- a/tasks/scripts/create-pivnet-metadata
+++ b/tasks/scripts/create-pivnet-metadata
@@ -14,7 +14,7 @@ echo "release:
     Concourse for VMware Tanzu v$(cat version/version) requires PostgreSQL 9.5+ 
   release_notes_url: https://docs.pivotal.io/p-concourse/v5/rn/
   availability: Admins Only
-  end_of_support_date: ((end_of_general_support))
+  end_of_support_date: $END_OF_GENERAL_SUPPORT
 product_files:
 - file: $(ls concourse-release-final/concourse-*.tgz)
   upload_as: Concourse BOSH $(cat version/version)


### PR DESCRIPTION
I have successfully tested this on pivnet-integration.cfapps.io by modifying
the pipeline template slightly and changing release-5.5.x so that the latest
version that has passed topgun gets uploaded.

https://pivnet-integration.cfapps.io/products/p-concourse#/releases/633803

In order to see this at work we'd need to wait until the next time `shipit`
gets used, since part of this change involves threading the stemcell.

looking forward, it would be nice to parameterize/dynamically determine:
* the release notes URL
* the stemcell family
* the supported versions of Postgres