### PR TITLE
Auto bump the chart version when publishing

### DIFF
--- a/pipelines/helm-chart.yml
+++ b/pipelines/helm-chart.yml
@@ -57,6 +57,35 @@ jobs:
         repository: concourse
         merge: true
 
+- name: publish-chart-patch
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - put: version
+      params: {bump: patch}
+    - get: concourse-chart
+    - get: chart-repo-index
+    - get: ci
+  - task: bump-chart-version
+    file: ci/tasks/bump-chart-version.yml
+  - task: package-chart
+    file: ci/tasks/package-chart.yml
+  - in_parallel:
+    - put: chart-repo-index
+      inputs: [packaged-chart]
+      params:
+        file: packaged-chart/index.yaml
+    - put: chart-repo
+      inputs: [packaged-chart]
+      params:
+        file: packaged-chart/concourse-*.tgz
+    - put: concourse-chart
+      inputs: [concourse-chart]
+      params:
+        repository: concourse
+        merge: true
+
 resources:
 - name: version
   type: semver
@@ -69,7 +98,7 @@ resources:
 
 - name: concourse-chart
   type: git
-  icon: *git-icon
+  icon: github
   source:
     uri: git@github.com:concourse/concourse-chart.git
     branch: master
@@ -88,3 +117,10 @@ resources:
     bucket: concourse-charts
     json_key: ((concourse_charts_json_key))
     versioned_file: index.yaml
+
+- name: ci
+  type: git
+  icon: github
+  source:
+    uri: https://github.com/concourse/ci.git
+    branch: master

--- a/pipelines/helm-chart.yml
+++ b/pipelines/helm-chart.yml
@@ -4,7 +4,7 @@ jobs:
   serial: true
   plan:
   - in_parallel:
-    - put: version
+    - get: version
       params: {bump: major}
     - get: concourse-chart
     - get: chart-repo-index
@@ -14,6 +14,8 @@ jobs:
   - task: package-chart
     file: ci/tasks/package-chart.yml
   - in_parallel:
+    - put: version
+      params: {file: version/version}
     - put: chart-repo-index
       inputs: [packaged-chart]
       params:
@@ -33,7 +35,7 @@ jobs:
   serial: true
   plan:
   - in_parallel:
-    - put: version
+    - get: version
       params: {bump: minor}
     - get: concourse-chart
     - get: chart-repo-index
@@ -43,6 +45,8 @@ jobs:
   - task: package-chart
     file: ci/tasks/package-chart.yml
   - in_parallel:
+    - put: version
+      params: {file: version/version}
     - put: chart-repo-index
       inputs: [packaged-chart]
       params:
@@ -62,7 +66,7 @@ jobs:
   serial: true
   plan:
   - in_parallel:
-    - put: version
+    - get: version
       params: {bump: patch}
     - get: concourse-chart
     - get: chart-repo-index
@@ -72,6 +76,8 @@ jobs:
   - task: package-chart
     file: ci/tasks/package-chart.yml
   - in_parallel:
+    - put: version
+      params: {file: version/version}
     - put: chart-repo-index
       inputs: [packaged-chart]
       params:

--- a/pipelines/helm-chart.yml
+++ b/pipelines/helm-chart.yml
@@ -1,0 +1,90 @@
+jobs:
+- name: publish-chart-major
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - put: version
+      params: {bump: major}
+    - get: concourse-chart
+    - get: chart-repo-index
+    - get: ci
+  - task: bump-chart-version
+    file: ci/tasks/bump-chart-version.yml
+  - task: package-chart
+    file: ci/tasks/package-chart.yml
+  - in_parallel:
+    - put: chart-repo-index
+      inputs: [packaged-chart]
+      params:
+        file: packaged-chart/index.yaml
+    - put: chart-repo
+      inputs: [packaged-chart]
+      params:
+        file: packaged-chart/concourse-*.tgz
+    - put: concourse-chart
+      inputs: [concourse-chart]
+      params:
+        repository: concourse
+        merge: true
+
+- name: publish-chart-minor
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - put: version
+      params: {bump: minor}
+    - get: concourse-chart
+    - get: chart-repo-index
+    - get: ci
+  - task: bump-chart-version
+    file: ci/tasks/bump-chart-version.yml
+  - task: package-chart
+    file: ci/tasks/package-chart.yml
+  - in_parallel:
+    - put: chart-repo-index
+      inputs: [packaged-chart]
+      params:
+        file: packaged-chart/index.yaml
+    - put: chart-repo
+      inputs: [packaged-chart]
+      params:
+        file: packaged-chart/concourse-*.tgz
+    - put: concourse-chart
+      inputs: [concourse-chart]
+      params:
+        repository: concourse
+        merge: true
+
+resources:
+- name: version
+  type: semver
+  icon: tag
+  source:
+    driver: gcs
+    bucket: concourse-artifacts
+    json_key: ((concourse_artifacts_json_key))
+    key: chart-version
+
+- name: concourse-chart
+  type: git
+  icon: *git-icon
+  source:
+    uri: git@github.com:concourse/concourse-chart.git
+    branch: master
+    private_key: ((concourse_chart_private_key))
+
+- name: chart-repo
+  type: gcs
+  source:
+    bucket: concourse-charts
+    json_key: ((concourse_charts_json_key))
+    regexp: concourse-(.*)\.tgz
+
+- name: chart-repo-index
+  type: gcs
+  source:
+    bucket: concourse-charts
+    json_key: ((concourse_charts_json_key))
+    versioned_file: index.yaml

--- a/pipelines/helm-chart.yml
+++ b/pipelines/helm-chart.yml
@@ -124,3 +124,8 @@ resources:
   source:
     uri: https://github.com/concourse/ci.git
     branch: master
+
+resource_types:
+- name: gcs
+  type: registry-image
+  source: {repository: frodenas/gcs-resource}

--- a/pipelines/helm-chart.yml
+++ b/pipelines/helm-chart.yml
@@ -23,7 +23,7 @@ jobs:
     - get: ci
   - task: bump-chart-app-version
     file: ci/tasks/bump-chart-app-version.yml
-  - put: push-and-merge-to-master
+  - put: merge-dev-into-master
     resource: concourse-chart
     inputs: [concourse-chart-dev]
     params:

--- a/pipelines/helm-chart.yml
+++ b/pipelines/helm-chart.yml
@@ -1,15 +1,35 @@
 groups:
+- name: dependencies
+  jobs:
+  - bump-concourse-version
+
 - name: publish
   jobs:
   - publish-chart-major
   - publish-chart-minor
   - publish-chart-patch
 
-- name: dependencies
-  jobs:
-  - bump-concourse-version
 
 jobs:
+- name: bump-concourse-version
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse-release
+      params:
+        globs: [none]
+    - get: concourse-chart-dev
+    - get: ci
+  - task: bump-chart-app-version
+    file: ci/tasks/bump-chart-app-version.yml
+  - put: push-and-merge-to-master
+    resource: concourse-chart
+    inputs: [concourse-chart-dev]
+    params:
+      repository: concourse-chart-dev
+      merge: true
+
 - name: publish-chart-major
   public: true
   serial: true
@@ -38,7 +58,7 @@ jobs:
     - put: concourse-chart
       inputs: [concourse-chart]
       params:
-        repository: concourse
+        repository: concourse-chart
         merge: true
         tag: version/version
         tag_prefix: v
@@ -71,7 +91,7 @@ jobs:
     - put: concourse-chart
       inputs: [concourse-chart]
       params:
-        repository: concourse
+        repository: concourse-chart
         merge: true
         tag: version/version
         tag_prefix: v
@@ -104,28 +124,10 @@ jobs:
     - put: concourse-chart
       inputs: [concourse-chart]
       params:
-        repository: concourse
+        repository: concourse-chart
         merge: true
         tag: version/version
         tag_prefix: v
-
-- name: bump-concourse-version
-  public: true
-  serial: true
-  plan:
-  - in_parallel:
-    - get: concourse-release
-      params:
-        globs: [none]
-    - get: concourse-chart
-    - get: ci
-  - task: bump-chart-app-version
-    file: ci/tasks/bump-chart-app-version.yml
-  - put: concourse-chart
-    inputs: [concourse-chart]
-    params:
-      repository: concourse
-      merge: true
 
 resources:
 - name: version
@@ -143,6 +145,14 @@ resources:
   source:
     uri: git@github.com:concourse/concourse-chart.git
     branch: master
+    private_key: ((concourse_chart_private_key))
+
+- name: concourse-chart-dev
+  type: git
+  icon: github
+  source:
+    uri: git@github.com:concourse/concourse-chart.git
+    branch: dev
     private_key: ((concourse_chart_private_key))
 
 - name: chart-repo

--- a/pipelines/helm-chart.yml
+++ b/pipelines/helm-chart.yml
@@ -1,3 +1,14 @@
+groups:
+- name: publish
+  jobs:
+  - publish-chart-major
+  - publish-chart-minor
+  - publish-chart-patch
+
+- name: dependencies
+  jobs:
+  - bump-concourse-version
+
 jobs:
 - name: publish-chart-major
   public: true
@@ -98,6 +109,24 @@ jobs:
         tag: version/version
         tag_prefix: v
 
+- name: bump-concourse-version
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse-release
+      params:
+        globs: [none]
+    - get: concourse-chart
+    - get: ci
+  - task: bump-chart-app-version
+    file: ci/tasks/bump-chart-app-version.yml
+  - put: concourse-chart
+    inputs: [concourse-chart]
+    params:
+      repository: concourse
+      merge: true
+
 resources:
 - name: version
   type: semver
@@ -136,6 +165,13 @@ resources:
   source:
     uri: https://github.com/concourse/ci.git
     branch: master
+
+- name: concourse-release
+  type: github-release
+  source:
+    owner: concourse
+    repository: concourse
+    access_token: ((concourse_github_release.access_token))
 
 resource_types:
 - name: gcs

--- a/pipelines/helm-chart.yml
+++ b/pipelines/helm-chart.yml
@@ -62,6 +62,8 @@ jobs:
       params:
         repository: concourse
         merge: true
+        tag: version/version
+        tag_prefix: v
 
 - name: publish-chart-patch
   public: true
@@ -93,6 +95,8 @@ jobs:
       params:
         repository: concourse
         merge: true
+        tag: version/version
+        tag_prefix: v
 
 resources:
 - name: version

--- a/pipelines/helm-chart.yml
+++ b/pipelines/helm-chart.yml
@@ -29,6 +29,8 @@ jobs:
       params:
         repository: concourse
         merge: true
+        tag: version/version
+        tag_prefix: v
 
 - name: publish-chart-minor
   public: true

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -182,6 +182,8 @@ jobs:
     trigger: true
   - set_pipeline: concourse
     file: pipelines-and-tasks/pipelines/concourse.yml
+  - set_pipeline: helm-chart
+    file: pipelines-and-tasks/pipelines/helm-chart.yml
   - set_pipeline: helm-prs
     file: pipelines-and-tasks/pipelines/helm-prs.yml
     vars:

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -75,7 +75,6 @@ groups:
   - bump-cbd-versions
   - publish-docs
   - ship-chart
-  - publish-chart-patch
   - patch
   - discover-component-version
 
@@ -1068,41 +1067,6 @@ jobs:
     - get: unit-image
       passed: [k8s-topgun]
 
-- name: publish-chart-patch
-  public: true
-  serial: true
-  plan:
-  - in_parallel:
-    - get: concourse-version
-      resource: version
-      passed: [ship-chart]
-    - get: concourse-chart
-      passed: [ship-chart]
-    - get: unit-image
-      passed: [ship-chart]
-    - get: chart-repo-index
-    - get: ci
-    - put: chart-version
-      params:
-        bump: patch
-  - task: build-chart
-    image: unit-image
-    file: ci/tasks/package-chart.yml
-  - in_parallel:
-    - put: chart-repo-index
-      inputs: [packaged-chart]
-      params:
-        file: packaged-chart/index.yaml
-    - put: chart-repo
-      inputs: [packaged-chart]
-      params:
-        file: packaged-chart/concourse-*.tgz
-    - put: concourse-chart
-      inputs: [concourse]
-      params:
-        repository: concourse
-        merge: true
-
 - name: patch
   public: true
   serial_groups: [version]
@@ -1625,12 +1589,3 @@ resources:
     start: 2AM
     stop: 3AM
     interval: 1h
-
-- name: chart-version
-  type: semver
-  icon: tag
-  source:
-    driver: gcs
-    bucket: concourse-artifacts
-    json_key: ((concourse_artifacts_json_key))
-    key: chart-version-((release_minor))

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -75,7 +75,7 @@ groups:
   - bump-cbd-versions
   - publish-docs
   - ship-chart
-  - publish-chart
+  - publish-chart-patch
   - patch
   - discover-component-version
 
@@ -1068,7 +1068,7 @@ jobs:
     - get: unit-image
       passed: [k8s-topgun]
 
-- name: publish-chart
+- name: publish-chart-patch
   public: true
   serial: true
   plan:
@@ -1082,6 +1082,9 @@ jobs:
       passed: [ship-chart]
     - get: chart-repo-index
     - get: ci
+    - put: chart-version
+      params:
+        bump: patch
   - task: build-chart
     image: unit-image
     file: ci/tasks/package-chart.yml
@@ -1622,3 +1625,12 @@ resources:
     start: 2AM
     stop: 3AM
     interval: 1h
+
+- name: chart-version
+  type: semver
+  icon: tag
+  source:
+    driver: gcs
+    bucket: concourse-artifacts
+    json_key: ((concourse_artifacts_json_key))
+    key: chart-version-((release_minor))

--- a/tasks/bump-chart-app-version.yml
+++ b/tasks/bump-chart-app-version.yml
@@ -6,12 +6,12 @@ image_resource:
   source: {repository: concourse/unit}
 
 inputs:
-- name: concourse-chart
+- name: concourse-chart-dev
 - name: concourse-release
 - name: ci
 
 outputs:
-- name: concourse-chart
+- name: concourse-chart-dev
 
 run:
   path: ci/tasks/scripts/bump-chart-app-version

--- a/tasks/bump-chart-app-version.yml
+++ b/tasks/bump-chart-app-version.yml
@@ -1,0 +1,17 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/unit}
+
+inputs:
+- name: concourse-chart
+- name: concourse-release
+- name: ci
+
+outputs:
+- name: concourse-chart
+
+run:
+  path: ci/tasks/scripts/bump-chart-app-version

--- a/tasks/bump-chart-version.yml
+++ b/tasks/bump-chart-version.yml
@@ -7,11 +7,12 @@ image_resource:
 
 inputs:
 - name: concourse-chart
-- name: chart-repo-index
+- name: version
 - name: ci
 
 outputs:
-- name: packaged-chart
+- name: concourse-chart
+  path: concourse
 
 run:
-  path: ci/tasks/scripts/package-chart
+  path: ci/tasks/scripts/bump-chart-version

--- a/tasks/scripts/bump-chart-app-version
+++ b/tasks/scripts/bump-chart-app-version
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e -x
+
+concourse_version=$(cat concourse-release/version)
+
+pushd concourse-chart
+  sed -i "s/appVersion: .*/appVersion: ${concourse_version}/g" Chart.yaml
+  sed -i "s/imageTag: .*/imageTag: \"${concourse_version}\"/g" values.yaml
+  sed -i "s/Concourse image version | .* |/Concourse image version | \`${concourse_version}\` |/g" README.md
+
+  git config --global user.email "ci@localhost"
+  git config --global user.name "CI Bot"
+
+  git add -A
+  git commit -m "bump app version and image tag"
+popd

--- a/tasks/scripts/bump-chart-app-version
+++ b/tasks/scripts/bump-chart-app-version
@@ -4,7 +4,7 @@ set -e -x
 
 concourse_version=$(cat concourse-release/version)
 
-pushd concourse-chart
+pushd concourse-chart-dev
   sed -i "s/appVersion: .*/appVersion: ${concourse_version}/g" Chart.yaml
   sed -i "s/imageTag: .*/imageTag: \"${concourse_version}\"/g" values.yaml
   sed -i "s/Concourse image version | .* |/Concourse image version | \`${concourse_version}\` |/g" README.md

--- a/tasks/scripts/bump-chart-version
+++ b/tasks/scripts/bump-chart-version
@@ -2,13 +2,9 @@
 
 set -e -x
 
-# workaround for an issue with `helm package` not liking when the chart name != dirName it's under
-# can be renamed to 'bumped-chart' or something more sensible once we're on helm v3
-git clone ./concourse-chart ./concourse
-
 chart_version=$(cat version/version)
 
-pushd concourse
+pushd concourse-chart
   sed -i "s/version: .*/version: ${chart_version}/g" Chart.yaml
 
   git config --global user.email "ci@localhost"

--- a/tasks/scripts/bump-chart-version
+++ b/tasks/scripts/bump-chart-version
@@ -16,5 +16,4 @@ pushd concourse
 
   git add -A
   git commit -m "bump chart version"
-  git tag -f "v$chart_version"
 popd

--- a/tasks/scripts/bump-chart-version
+++ b/tasks/scripts/bump-chart-version
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e -x
+
+# workaround for an issue with `helm package` not liking when the chart name != dirName it's under
+# can be renamed to 'bumped-chart' or something more sensible once we're on helm v3
+git clone ./concourse-chart ./concourse
+
+chart_version=$(cat version/version)
+
+pushd concourse
+  sed -i "s/version: .*/version: ${chart_version}/g" Chart.yaml
+
+  git config --global user.email "ci@localhost"
+  git config --global user.name "CI Bot"
+
+  git add -A
+  git commit -m "bump chart version"
+  git tag -f "v$chart_version"
+popd

--- a/tasks/scripts/package-chart
+++ b/tasks/scripts/package-chart
@@ -6,23 +6,6 @@ set -e -x
 # can be renamed to 'bumped-chart' or something more sensible once we're on helm v3
 git clone ./concourse-chart ./concourse
 
-chart_version=$(cat chart-version/version)
-concourse_version=$(cat concourse-version/version)
-
-pushd concourse
-  sed -i "s/version: .*/version: ${chart_version}/g" Chart.yaml
-  sed -i "s/appVersion: .*/appVersion: ${concourse_version}/g" Chart.yaml
-  sed -i "s/imageTag: .*/imageTag: \"${concourse_version}\"/g" values.yaml
-  sed -i "s/Concourse image version | .* |/Concourse image version | \`${concourse_version}\` |/g" README.md
-
-  git config --global user.email "ci@localhost"
-  git config --global user.name "CI Bot"
-
-  git add -A
-  git commit -m "bump chart version"
-  git tag -f "v$chart_version"
-popd
-
 helm init --client-only
 helm repo remove local
 helm repo update

--- a/tasks/scripts/package-chart
+++ b/tasks/scripts/package-chart
@@ -6,6 +6,23 @@ set -e -x
 # can be renamed to 'bumped-chart' or something more sensible once we're on helm v3
 git clone ./concourse-chart ./concourse
 
+chart_version=$(cat chart-version/version)
+concourse_version=$(cat concourse-version/version)
+
+pushd concourse
+  sed -i "s/version: .*/version: ${chart_version}/g" Chart.yaml
+  sed -i "s/appVersion: .*/appVersion: ${concourse_version}/g" Chart.yaml
+  sed -i "s/imageTag: .*/imageTag: \"${concourse_version}\"/g" values.yaml
+  sed -i "s/Concourse image version | .* |/Concourse image version | \`${concourse_version}\` |/g" README.md
+
+  git config --global user.email "ci@localhost"
+  git config --global user.name "CI Bot"
+
+  git add -A
+  git commit -m "bump chart version"
+  git tag -f "v$chart_version"
+popd
+
 helm init --client-only
 helm repo remove local
 helm repo update


### PR DESCRIPTION
This PR contains a new pipeline with four jobs. Three of the jobs do the same series of steps:

* bump the chart version (different version bump depending on the job)
* package the chart using `helm`
  * creates a zip file of the chart
  * updates the index.yaml which tracks all version of the chart
* upload the zip file to gcs
* upload index.yaml to gcs
* Pushes the commit and tags it with the new chart version to the `master` branch

The fourth job bumps the Concourse app version automatically by:
* merging the `dev` branch into `master` 
* updating the `appVersion` and `imageTag` fields

I'm able to set the pipeline. I unpaused it as well and ensured all the checks ran successfully.
<img width="717" alt="image" src="https://user-images.githubusercontent.com/4583837/83826689-84bf4480-a6aa-11ea-9f91-04f72e9144be.png">


I tested all of the new tasks by using `fly execute` and confirming the output contained the commits I expected with the right diffs.

---
Some stuff was borrowed from this commit:
22456bc6d80ae7096880f375417e640bf263092b