### PR TITLE
Fix path to file containing status of Norsk pipelines' jobs

### DIFF
--- a/pipelines/norsk-mirror.yml
+++ b/pipelines/norsk-mirror.yml
@@ -46,6 +46,8 @@ jobs:
   - get: ci
   - task: check-status-file
     file: ci/tasks/check-norsk-status.yml
+    params:
+      NORSK_PIPELINE: p-concourse
     input_mapping: {scan-status: latest-scan-status}
   on_success:
     do:
@@ -81,6 +83,8 @@ jobs:
   - get: ci
   - task: check-status-file
     file: ci/tasks/check-norsk-status.yml
+    params:
+      NORSK_PIPELINE: p-concourse-4.2.x
     input_mapping: {scan-status: 4.2.x-scan-status}
   on_success:
     do:
@@ -116,6 +120,8 @@ jobs:
     - get: ci
     - task: check-status-file
       file: ci/tasks/check-norsk-status.yml
+      params:
+        NORSK_PIPELINE: p-concourse-5.5.x
       input_mapping: {scan-status: 5.5.x-scan-status}
   on_success:
     do:

--- a/pipelines/norsk-mirror.yml
+++ b/pipelines/norsk-mirror.yml
@@ -51,25 +51,17 @@ jobs:
     input_mapping: {scan-status: latest-scan-status}
   on_success:
     do:
-    - task: format-slack-message
-      file: ci/tasks/format-slack-message.yml
-      input_mapping: {src: latest-scan-status}
-      params:
-        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
-        SLACK_TOKEN: ((slack_token))
     - put: notify
       params:
-        message_file: message/message
         mode: normal
         alert_type: fixed
   on_failure:
     do:
-    - task: format-slack-message
-      file: ci/tasks/format-slack-message.yml
+    - task: format-slack-message-norsk
+      file: ci/tasks/format-slack-message-norsk.yml
       input_mapping: {src: latest-scan-status}
       params:
-        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
-        SLACK_TOKEN: ((slack_token))
+        NORSK_PIPELINE: p-concourse
     - put: notify
       params:
         message_file: message/message
@@ -88,25 +80,17 @@ jobs:
     input_mapping: {scan-status: 4.2.x-scan-status}
   on_success:
     do:
-    - task: format-slack-message
-      file: ci/tasks/format-slack-message.yml
-      input_mapping: {src: 4.2.x-scan-status}
-      params:
-        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
-        SLACK_TOKEN: ((slack_token))
     - put: notify
       params:
-        message_file: message/message
         mode: normal
         alert_type: fixed
   on_failure:
     do:
-    - task: format-slack-message
-      file: ci/tasks/format-slack-message.yml
+    - task: format-slack-message-norsk
+      file: ci/tasks/format-slack-message-norsk.yml
       input_mapping: {src: 4.2.x-scan-status}
       params:
-        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
-        SLACK_TOKEN: ((slack_token))
+        NORSK_PIPELINE: p-concourse-4.2.x
     - put: notify
       params:
         message_file: message/message
@@ -125,25 +109,17 @@ jobs:
       input_mapping: {scan-status: 5.5.x-scan-status}
   on_success:
     do:
-      - task: format-slack-message
-        file: ci/tasks/format-slack-message.yml
-        input_mapping: {src: 5.5.x-scan-status}
-        params:
-          GITHUB_TOKEN: ((concourse_github_dummy.access_token))
-          SLACK_TOKEN: ((slack_token))
       - put: notify
         params:
-          message_file: message/message
           mode: normal
           alert_type: fixed
   on_failure:
     do:
-      - task: format-slack-message
-        file: ci/tasks/format-slack-message.yml
+      - task: format-slack-message-norsk
+        file: ci/tasks/format-slack-message-norsk.yml
         input_mapping: {src: 5.5.x-scan-status}
         params:
-          GITHUB_TOKEN: ((concourse_github_dummy.access_token))
-          SLACK_TOKEN: ((slack_token))
+          NORSK_PIPELINE: p-concourse-5.5.x
       - put: notify
         params:
           message_file: message/message

--- a/tasks/check-norsk-status.yml
+++ b/tasks/check-norsk-status.yml
@@ -4,6 +4,9 @@ image_resource:
   type: registry-image
   source: { repository: ubuntu }
 
+params:
+  NORSK_PIPELINE:
+
 inputs:
 - name: ci
 - name: scan-status

--- a/tasks/format-slack-message-norsk.yml
+++ b/tasks/format-slack-message-norsk.yml
@@ -1,0 +1,19 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: concourse/unit
+
+params:
+  NORSK_PIPELINE:
+
+inputs:
+  - name: ci
+  - name: src
+
+outputs:
+  - name: message
+
+run:
+  path: ci/tasks/scripts/format-slack-message-norsk

--- a/tasks/scripts/check-norsk-status
+++ b/tasks/scripts/check-norsk-status
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-status_file=scan-status/p-concourse/status.json
+status_file=scan-status/$NORSK_PIPELINE/status.json
 cat "$status_file"
 
 num_failures="$(grep -c '"status": "failed"' $status_file)"

--- a/tasks/scripts/format-slack-message-norsk
+++ b/tasks/scripts/format-slack-message-norsk
@@ -3,4 +3,4 @@
 set -e -x
 
 message_file="$PWD/message/message"
-echo $(jq -r '.jobs[] | select(.status == "failed") | .url' $PWD/src/$NORSK_PIPELINE/status.json) > $message_file
+jq -r '.jobs[] | select(.status == "failed") | .url' $PWD/src/$NORSK_PIPELINE/status.json > $message_file

--- a/tasks/scripts/format-slack-message-norsk
+++ b/tasks/scripts/format-slack-message-norsk
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e -x
+
+message_file="$PWD/message/message"
+echo $(jq -r '.jobs[] | select(.status == "failed") | .url' $PWD/src/$NORSK_PIPELINE/status.json) > $message_file


### PR DESCRIPTION
Currently, the script that reads status.json from [oslo-scan-status](https://github.com/pivotal/oslo-scan-status) repo doesn't take into consideration the different folders that exist based on pipeline names for concourse. So, the 3 existing jobs that should monitor norsk pipelines for different Concourse versions (p-concourse, p-concourse-4.2.x and p-concourse-5.5.x) read the file under p-concourse folder instead of their respective folder (named after each pipeline). The git resource properly watches for changes in the correct path, but the status.json file that the task reads from is actually the same for all 3 jobs. The PR fixes that issue by passing a param with the pipeline name to the task/script. 

The PR also changes the format of slack messages (for norsk-mirror related jobs) to not use the `yarn blame` method, since we read the status.json from a [repo](https://github.com/pivotal/oslo-scan-status) that gets updated by a bot. It now sends a message to slack with urls of builds that fail in our norsk pipelines.   