### PR TITLE
Ensure reconfigure pipeline configures itself first

### DIFF
--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -43,10 +43,18 @@ resources:
     uri: https://github.com/concourse/oxygen-mask
 
 jobs:
+- name: reconfigure-self
+  plan:
+  - get: pipelines-and-tasks
+    trigger: true
+  - set_pipeline: reconfigure-pipelines
+    file: pipelines-and-tasks/pipelines/reconfigure.yml
+
 - name: reconfigure-resource-pipelines
   plan:
   - get: pipelines-and-tasks
     trigger: true
+    passed: [reconfigure-self]
   - task: render-resource-templates
     file: pipelines-and-tasks/tasks/render-resource-pipeline-templates.yml
     params:
@@ -105,12 +113,11 @@ jobs:
   plan:
   - get: pipelines-and-tasks
     trigger: true
+    passed: [reconfigure-self]
   - get: baggageclaim-ci
     trigger: true
   - get: concourse-for-k8s
     trigger: true
-  - set_pipeline: reconfigure-pipelines
-    file: pipelines-and-tasks/pipelines/reconfigure.yml
   - set_pipeline: concourse
     file: pipelines-and-tasks/pipelines/concourse.yml
   - set_pipeline: prs


### PR DESCRIPTION
This PR adds a job that reconfigures the reconfigure pipeline itself. It avoids the situation where a new pipeline is added but it isn't actually added until the build is re-run.

Example: https://ci.concourse-ci.org/teams/main/pipelines/reconfigure-pipelines/jobs/reconfigure-pipelines/builds/164.1
<img width="444" alt="image" src="https://user-images.githubusercontent.com/4583837/81313200-8c60de80-9055-11ea-81ff-31d4ffd6e5e2.png">


This new first job still has this problem but at least it's isolated now
and won't occur for the majority of use-cases. We're not likely to change the first job often/ever.