### PR TITLE
Move PRs pipeline from main team to contributor team

### DIFF
--- a/pipelines/reconfigure-contributor.yml
+++ b/pipelines/reconfigure-contributor.yml
@@ -1,0 +1,31 @@
+resource_types:
+- name: concourse-pipeline
+  type: registry-image
+  source:
+    repository: concourse/concourse-pipeline-resource
+
+resources:
+- name: pipelines-and-tasks
+  type: git
+  icon: github-circle
+  source:
+    uri: https://github.com/concourse/ci
+    paths:
+    - pipelines
+    - tasks
+
+jobs:
+- name: reconfigure-self
+  plan:
+  - get: pipelines-and-tasks
+    trigger: true
+  - set_pipeline: reconfigure-pipelines
+    file: pipelines-and-tasks/pipelines/reconfigure-contributor.yml
+
+- name: reconfigure-pipelines
+  plan:
+  - get: pipelines-and-tasks
+    trigger: true
+    passed: [reconfigure-self]
+  - set_pipeline: prs
+    file: pipelines-and-tasks/pipelines/prs.yml

--- a/pipelines/reconfigure-contributor.yml
+++ b/pipelines/reconfigure-contributor.yml
@@ -1,9 +1,3 @@
-resource_types:
-- name: concourse-pipeline
-  type: registry-image
-  source:
-    repository: concourse/concourse-pipeline-resource
-
 resources:
 - name: pipelines-and-tasks
   type: git

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -120,8 +120,6 @@ jobs:
     trigger: true
   - set_pipeline: concourse
     file: pipelines-and-tasks/pipelines/concourse.yml
-  - set_pipeline: prs
-    file: pipelines-and-tasks/pipelines/prs.yml
   - set_pipeline: helm-prs
     file: pipelines-and-tasks/pipelines/helm-prs.yml
     vars:


### PR DESCRIPTION
See context on https://github.com/concourse/hush-house/pull/127

For security contributors should be limited to operator PRs pipeline only. With current implementation of Concourse RBAC configuration it can't do that if PRs pipeline stays in the
same team with others.

So this pull request moves PRs pipeline from main team to contributor team. Along with it I have to extract the reconfigure task for PRs pipeline from reconfigure.yml to its own since currently set_pipeline step will only set pipeline to current team.

For dev ops when setting reconfigure-contributor.yml, `fly login -n contributor` should be done first.