### PR TITLE
add containerd integration test to prs

### DIFF
--- a/pipelines/prs.yml
+++ b/pipelines/prs.yml
@@ -231,6 +231,45 @@ jobs:
       params: {BUILD: true, CONTAINERD: true, DOWNLOAD_CLI: false}
       tags: [pr]
 
+- name: containerd-integration
+  public: true
+  max_in_flight: 3
+  on_failure:
+    put: concourse-pr
+    inputs: [concourse-pr]
+    params: {path: concourse-pr, status: failure, context: containerd-integration}
+    tags: [pr]
+    get_params: {skip_download: true}
+  on_success:
+    put: concourse-pr
+    inputs: [concourse-pr]
+    params: {path: concourse-pr, status: success, context: containerd-integration}
+    tags: [pr]
+    get_params: {skip_download: true}
+  plan:
+  - in_parallel:
+    - get: concourse-pr
+      trigger: true
+      version: every
+      tags: [pr]
+    - get: dev-image
+      tags: [pr]
+    - get: ci
+      tags: [pr]
+  - put: concourse-status-update
+    resource: concourse-pr
+    inputs: [concourse-pr]
+    params: {path: concourse-pr, status: pending, context: containerd-integration}
+    tags: [pr]
+    get_params: {list_changed_files: true, skip_download: true}
+  - task: integration
+    image: dev-image
+    privileged: true
+    timeout: 1h
+    file: ci/tasks/containerd-integration.yml
+    tags: [pr]
+
+
 - name: watsjs
   public: true
   max_in_flight: 3

--- a/tasks/scripts/unit
+++ b/tasks/scripts/unit
@@ -23,4 +23,4 @@ go mod download
 
 go install github.com/onsi/ginkgo/ginkgo
 
-ginkgo -r -p -race -skipPackage testflight,topgun,./worker/backend/integration "$@"
+ginkgo -r -p -race -skipPackage testflight,topgun,./worker/runtime/integration,./worker/backend/integration "$@"


### PR DESCRIPTION
This test suite was running in the `concourse` pipeline but missing from
the `prs` pipeline.

Skipping `./worker/runtime/integration` in `unit` job script as the directory has been renamed. There will be PRs currently in the works that don't have the renamed directory. They would then fail on unit job. Contributors will likely be stumped and won't know to rebase. Therefore, keeping the original `./worker/backend/integration` in the list as well to avoid unnecessary
failures. This should be removed in a few weeks.