### PR TITLE
add missing input mapping to task

### DIFF
--- a/pipelines/prs.yml
+++ b/pipelines/prs.yml
@@ -267,6 +267,7 @@ jobs:
     privileged: true
     timeout: 1h
     file: ci/tasks/containerd-integration.yml
+    input_mapping: {concourse: concourse-pr}
     tags: [pr]
 
 


### PR DESCRIPTION
The containerd-integration.yml _task_ expects the concourse/concourse repo
as input, and with the input name "concourse". The `containerd-integration` _job_
in the prs pipeline refers to this repo as concourse-pr, and hence an
input mapping needs to be done when the _task_ is used in that particular
_job_.