### PR TITLE
Fix containerd integration tests

### DIFF
--- a/tasks/scripts/containerd-integration
+++ b/tasks/scripts/containerd-integration
@@ -18,7 +18,7 @@ run_test() {
   go mod download
   go install github.com/onsi/ginkgo/ginkgo
 
-  ginkgo -r -nodes=4 -race -keepGoing -slowSpecThreshold=15 ./worker/backend/integration "$@"
+  ginkgo -r -nodes=4 -race -keepGoing -slowSpecThreshold=15 ./worker/backend/integration ./worker/runtime/integration "$@"
 }
 
 main "$@"


### PR DESCRIPTION
In concourse/concourse worker/backend is being renamed to worker/runtime.
There will be prs currently in the works that don't have
the renamed directory. They would then fail on this job. Contributors
will likely be stumped and won't know to rebase. Therefore, keeping the original
./worker/backend/integration in the list as well to avoid unnecessary
failures. This should be removed in a few weeks.