### PR TITLE
Announcement Pipeline

### DIFF
--- a/pipelines/announcements.yml
+++ b/pipelines/announcements.yml
@@ -27,6 +27,7 @@ jobs:
       trigger: true
     - put: discord-announcement
       params:
+        # Posts to the announcement channel
         channel: "604321306846167051"
         title_file: concourse-blog/title
         message_file: concourse-blog/link

--- a/pipelines/blog-announcement.yml
+++ b/pipelines/blog-announcement.yml
@@ -1,0 +1,32 @@
+resource_types:
+- name: rss-resource
+  type: docker-image
+  source:
+    repository: suhlig/concourse-rss-resource
+    tag: latest
+- name: discord-resource
+  type: docker-image
+  source:
+    repository: taylorsilva/discord-resource
+
+resources:
+- name: concourse-blog
+  type: rss-resource
+  source:
+    url: "https://blog.concourse-ci.org/rss/"
+- name: discord-announcement
+  type: discord-resource
+  check_every: 999999h
+  source:
+    token: ((discord_bot_token))
+
+jobs:
+- name: post-blog-post-to-discord
+  plan:
+    - get: concourse-blog
+      trigger: true
+    - put: discord-announcement
+      params:
+        channel: "604321306846167051"
+        title_file: concourse-blog/title
+        message_file: concourse-blog/link

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -220,6 +220,8 @@ jobs:
     vars:
       concourse_chart_branch: release/6.1.x
       concourse_minor: "6.1"
+  - set_pipeline: blog-post-announcement
+    file: pipelines-and-tasks/pipelines/blog-announcement.yml
 
 - name: reconfigure-monitoring-pipeline
   plan:


### PR DESCRIPTION
Had the idea of making a pipeline that sends announcements to discord and slack whenever things like a new blog post come out or we publish a new version of Concourse, the chart, bosh release, etc.

Currently this pipeline posts to discord when new blog posts come out.