### PR TITLE
retry watsjs tests

### DIFF
--- a/pipelines/prs.yml
+++ b/pipelines/prs.yml
@@ -306,11 +306,11 @@ jobs:
     tags: [pr]
     get_params: {list_changed_files: true, skip_download: true}
   - task: yarn-build
-    attempts: 3
     file: ci/tasks/yarn-build.yml
     input_mapping: {concourse: concourse-pr}
     tags: [pr]
   - task: watsjs
+    attempts: 3
     timeout: 1h
     privileged: true
     file: ci/tasks/docker-compose-watsjs.yml

--- a/pipelines/prs.yml
+++ b/pipelines/prs.yml
@@ -306,6 +306,7 @@ jobs:
     tags: [pr]
     get_params: {list_changed_files: true, skip_download: true}
   - task: yarn-build
+    attempts: 3
     file: ci/tasks/yarn-build.yml
     input_mapping: {concourse: concourse-pr}
     tags: [pr]


### PR DESCRIPTION
Despite my efforts in concourse/concourse#5627, watsjs is still somewhat
flaky. It typically passes after 1 or 2 retries though. So, why not just
retry it automatically in the pipeline?

Signed-off-by: Aidan Oldershaw <aoldershaw@pivotal.io>