### PR TITLE
Mark old issues as stale and close shortly after

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: Mark stale issues
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has had no activity for a while. It has been labeled `stale`, and will be closed in one week.'
+        stale-issue-label: 'stale'
+        days-before-stale: 42
+        days-before-close: 7


### PR DESCRIPTION
Issues will be labelled `stale` after no activity for 6 weeks, and then be closed a week after that.