### PR TITLE
Remove worker/backend references

### DIFF
--- a/tasks/scripts/containerd-integration
+++ b/tasks/scripts/containerd-integration
@@ -16,9 +16,8 @@ run_test() {
   cd concourse
 
   go mod download
-  go install github.com/onsi/ginkgo/ginkgo
 
-  ginkgo -r -nodes=4 -race -keepGoing -slowSpecThreshold=15 ./worker/backend/integration ./worker/runtime/integration "$@"
+  go test -v -race ./worker/runtime/integration
 }
 
-main "$@"
+main

--- a/tasks/scripts/unit
+++ b/tasks/scripts/unit
@@ -23,4 +23,4 @@ go mod download
 
 go install github.com/onsi/ginkgo/ginkgo
 
-ginkgo -r -p -race -skipPackage testflight,topgun,./worker/runtime/integration,./worker/backend/integration "$@"
+ginkgo -r -p -race -skipPackage testflight,topgun,./worker/runtime/integration "$@"


### PR DESCRIPTION
Fixes #333 

`worker/backend` has been renamed to `worker/runtime` in [concourse/concourse](https://github.com/concourse/concourse/tree/master/worker/runtime). References to both were kept to prevent contributor PRs that did not have the latest master from failing in an inconspicuous way. 

`worker/runtime/integration` uses testify as its testing framework. Running `go test` directly is faster than running Ginkgo (30 seconds vs 1m 30 seconds). This was switched as a result.