### PR TITLE
fix path containing containerd binaries

### DIFF
--- a/dockerfiles/dev/Dockerfile-v6
+++ b/dockerfiles/dev/Dockerfile-v6
@@ -32,7 +32,7 @@ RUN chmod +x /usr/local/bin/dumb-init
 COPY gdn/gdn-* /usr/local/concourse/bin/gdn
 
 # Copies files from the bin directory of the tarball to /usr/local/concourse/bin
-ADD containerd/containerd-*.linux-amd64.tar.gz /usr/local/concourse
+ADD containerd/containerd-*-linux-amd64.tar.gz /usr/local/concourse
 
 COPY runc/runc.amd64 /usr/local/concourse/bin/runc
 


### PR DESCRIPTION
related: containerd/containerd#4348

containerd changed how they package their releases, and changed
the name of the bundle containing the binaries - this broke our dev
image, since we no longer had the `containerd` binary.

Signed-off-by: Aidan Oldershaw <aoldershaw@pivotal.io>