### PR TITLE
Integrate release note generator

### DIFF
--- a/pipelines/release-v6.yml
+++ b/pipelines/release-v6.yml
@@ -883,7 +883,6 @@ jobs:
     - get: release-me
     - get: ci
     - get: concourse
-      trigger: true
       passed:
       - build-rc
       - bosh-smoke
@@ -897,39 +896,11 @@ jobs:
       - bosh-smoke
       - bosh-topgun
       - bosh-check-props
-  - in_parallel:
-    - task: build-release-name
-      file: ci/tasks/build-release-name.yml
-    - task: build-release-notes
-      file: ci/tasks/build-release-notes.yml
-      params:
-        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
-        GITHUB_BRANCH: release/((release_minor)).x
-  - put: concourse-draft-release
-    params:
-      commitish: concourse/.git/ref
-      tag: version/version
-      tag_prefix: v
-      name: release-name/release-name
-      body: built-notes/notes.md
-
-
-- name: shipit
-  public: true
-  serial_groups: [version]
-  plan:
-  - in_parallel:
-    - get: concourse
-      passed: [create-draft-release]
     - get: unit-image
       passed:
       - build-rc
       - bosh-smoke
       - bosh-topgun
-    - get: final-version
-      resource: version
-      params: {bump: final}
-      passed: [create-draft-release]
     - get: linux-rc
       passed: [build-rc]
     - get: linux-rc-ubuntu
@@ -951,6 +922,60 @@ jobs:
       passed: [bosh-topgun]
     - get: uaa-release
       passed: [bosh-topgun]
+  - in_parallel:
+    - task: build-release-name
+      file: ci/tasks/build-release-name.yml
+      input_mapping: {version: final-version}
+    - task: build-release-notes
+      file: ci/tasks/build-release-notes.yml
+      params:
+        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
+        GITHUB_BRANCH: release/((release_minor)).x
+  - put: concourse-draft-release
+    inputs: [concourse, final-version, release-name, built-notes]
+    params:
+      commitish: concourse/.git/ref
+      tag: final-version/version
+      tag_prefix: v
+      name: release-name/release-name
+      body: built-notes/notes.md
+
+
+- name: shipit
+  public: true
+  serial_groups: [version]
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [create-draft-release]
+    - get: unit-image
+      passed: [create-draft-release]
+    - get: final-version
+      resource: version
+      params: {bump: final}
+      passed: [create-draft-release]
+    - get: linux-rc
+      passed: [create-draft-release]
+    - get: linux-rc-ubuntu
+      passed: [create-draft-release]
+    - get: windows-rc
+      passed: [create-draft-release]
+    - get: darwin-rc
+      passed: [create-draft-release]
+    - get: concourse-rc-image
+      passed: [create-draft-release]
+    - get: concourse-rc-image-ubuntu
+      passed: [create-draft-release]
+    - get: concourse-release
+      passed: [create-draft-release]
+    - get: bpm-release
+      passed: [create-draft-release]
+    - get: postgres-release
+      passed: [create-draft-release]
+    - get: credhub-release
+      passed: [create-draft-release]
+    - get: uaa-release
+      passed: [create-draft-release]
   - put: version
     params: {file: final-version/version}
 

--- a/pipelines/release-v6.yml
+++ b/pipelines/release-v6.yml
@@ -883,16 +883,12 @@ jobs:
     - get: release-me
     - get: ci
     - get: concourse
+      trigger: true
       passed:
       - build-rc
       - bosh-smoke
       - bosh-topgun
       - bosh-check-props
-    - get: unit-image
-      passed:
-      - build-rc
-      - bosh-smoke
-      - bosh-topgun
     - get: final-version
       resource: version
       params: {bump: final}
@@ -901,6 +897,39 @@ jobs:
       - bosh-smoke
       - bosh-topgun
       - bosh-check-props
+  - in_parallel:
+    - task: build-release-name
+      file: ci/tasks/build-release-name.yml
+    - task: build-release-notes
+      file: ci/tasks/build-release-notes.yml
+      params:
+        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
+        GITHUB_BRANCH: release/((release_minor)).x
+  - put: concourse-draft-release
+    params:
+      commitish: concourse/.git/ref
+      tag: version/version
+      tag_prefix: v
+      name: release-name/release-name
+      body: built-notes/notes.md
+
+
+- name: shipit
+  public: true
+  serial_groups: [version]
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [create-draft-release]
+    - get: unit-image
+      passed:
+      - build-rc
+      - bosh-smoke
+      - bosh-topgun
+    - get: final-version
+      resource: version
+      params: {bump: final}
+      passed: [create-draft-release]
     - get: linux-rc
       passed: [build-rc]
     - get: linux-rc-ubuntu
@@ -922,57 +951,6 @@ jobs:
       passed: [bosh-topgun]
     - get: uaa-release
       passed: [bosh-topgun]
-  - in_parallel:
-    - task: build-release-name
-      file: ci/tasks/build-release-name.yml
-    - task: build-release-notes
-      file: ci/tasks/build-release-notes.yml
-      params:
-        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
-  - put: concourse-draft-release
-    params:
-      commitish: concourse/.git/ref
-      tag: version/version
-      tag_prefix: v
-      name: release-name/release-name
-      body: built-notes/notes.md
-
-
-- name: shipit
-  public: true
-  serial_groups: [version]
-  plan:
-  - in_parallel:
-    - get: concourse
-      passed: [create-draft-release]
-    - get: unit-image
-      passed: [create-draft-release]
-    - get: final-version
-      resource: version
-      params: {bump: final}
-      passed: [create-draft-release]
-    - get: linux-rc
-      passed: [create-draft-release]
-    - get: linux-rc-ubuntu
-      passed: [create-draft-release]
-    - get: windows-rc
-      passed: [create-draft-release]
-    - get: darwin-rc
-      passed: [create-draft-release]
-    - get: concourse-rc-image
-      passed: [create-draft-release]
-    - get: concourse-rc-image-ubuntu
-      passed: [create-draft-release]
-    - get: concourse-release
-      passed: [create-draft-release]
-    - get: bpm-release
-      passed: [create-draft-release]
-    - get: postgres-release
-      passed: [create-draft-release]
-    - get: credhub-release
-      passed: [create-draft-release]
-    - get: uaa-release
-      passed: [create-draft-release]
   - put: version
     params: {file: final-version/version}
 

--- a/pipelines/release-v6.yml
+++ b/pipelines/release-v6.yml
@@ -63,6 +63,7 @@ groups:
 
 - name: publish
   jobs:
+  - create-draft-release
   - shipit
   - publish-binaries
   - publish-image
@@ -875,11 +876,12 @@ jobs:
   on_failure: *failed-concourse
   on_error: *failed-concourse
 
-- name: shipit
+- name: create-draft-release
   public: true
-  serial_groups: [version]
   plan:
   - in_parallel:
+    - get: release-me
+    - get: ci
     - get: concourse
       passed:
       - build-rc
@@ -920,6 +922,57 @@ jobs:
       passed: [bosh-topgun]
     - get: uaa-release
       passed: [bosh-topgun]
+  - in_parallel:
+    - task: build-release-name
+      file: ci/tasks/build-release-name.yml
+    - task: build-release-notes
+      file: ci/tasks/build-release-notes.yml
+      params:
+        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
+  - put: concourse-draft-release
+    params:
+      commitish: concourse/.git/ref
+      tag: version/version
+      tag_prefix: v
+      name: release-name/release-name
+      body: built-notes/notes.md
+
+
+- name: shipit
+  public: true
+  serial_groups: [version]
+  plan:
+  - in_parallel:
+    - get: concourse
+      passed: [create-draft-release]
+    - get: unit-image
+      passed: [create-draft-release]
+    - get: final-version
+      resource: version
+      params: {bump: final}
+      passed: [create-draft-release]
+    - get: linux-rc
+      passed: [create-draft-release]
+    - get: linux-rc-ubuntu
+      passed: [create-draft-release]
+    - get: windows-rc
+      passed: [create-draft-release]
+    - get: darwin-rc
+      passed: [create-draft-release]
+    - get: concourse-rc-image
+      passed: [create-draft-release]
+    - get: concourse-rc-image-ubuntu
+      passed: [create-draft-release]
+    - get: concourse-release
+      passed: [create-draft-release]
+    - get: bpm-release
+      passed: [create-draft-release]
+    - get: postgres-release
+      passed: [create-draft-release]
+    - get: credhub-release
+      passed: [create-draft-release]
+    - get: uaa-release
+      passed: [create-draft-release]
   - put: version
     params: {file: final-version/version}
 
@@ -970,23 +1023,19 @@ jobs:
     - get: darwin-rc
       passed: [shipit]
     - get: ci
-    - get: release-notes
   - in_parallel:
     - task: prep-release-assets
       file: ci/tasks/prep-release-assets.yml
       image: unit-image
-    - task: build-release-notes
-      file: ci/tasks/build-release-notes.yml
+    - task: build-release-name
+      file: ci/tasks/build-release-name.yml
       image: unit-image
-      params:
-        GITHUB_TOKEN: ((concourse_github_dummy.access_token))
   - put: concourse-github-release
     params:
       commitish: concourse/.git/ref
       tag: version/version
       tag_prefix: v
-      name: built-notes/release-name
-      body: built-notes/notes.md
+      name: release-name/release-name
       globs:
       - concourse-linux/concourse-*.tgz
       - concourse-windows/concourse-*.zip
@@ -1127,15 +1176,6 @@ resources:
   source:
     uri: https://github.com/concourse/ci.git
     branch: master
-
-- name: release-notes
-  type: git
-  icon: *git-icon
-  source:
-    uri: https://github.com/concourse/concourse.git
-    branch: release/((release_minor)).x
-    paths:
-    - release-notes/
 
 - name: concourse-docker
   type: git
@@ -1348,6 +1388,15 @@ resources:
   source:
     uri: https://github.com/helm/charts
     branch: master
+
+- name: concourse-draft-release
+  type: github-release
+  icon: *release-icon
+  source:
+    drafts: true
+    owner: concourse
+    repository: concourse
+    access_token: ((concourse_github_release.access_token))
 
 - name: concourse-github-release
   type: github-release
@@ -1613,3 +1662,9 @@ resources:
   type: time
   source:
     interval: 24h
+
+- name: release-me
+  type: github-release
+  source:
+    owner: clarafu
+    repository: release-me

--- a/tasks/build-release-name.yml
+++ b/tasks/build-release-name.yml
@@ -6,14 +6,12 @@ image_resource:
   source: {repository: concourse/unit}
 
 inputs:
-- name: release-me
+- name: version
+  optional: true
 - name: ci
 
 outputs:
-- name: built-notes
-
-params:
-  GITHUB_TOKEN:
+- name: release-name
 
 run:
-  path: ci/tasks/scripts/build-release-notes
+  path: ci/tasks/scripts/build-release-name

--- a/tasks/build-release-notes.yml
+++ b/tasks/build-release-notes.yml
@@ -8,12 +8,14 @@ image_resource:
 inputs:
 - name: release-me
 - name: ci
+- name: concourse
 
 outputs:
 - name: built-notes
 
 params:
   GITHUB_TOKEN:
+  GITHUB_BRANCH:
 
 run:
   path: ci/tasks/scripts/build-release-notes

--- a/tasks/scripts/build-release-name
+++ b/tasks/scripts/build-release-name
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ -d version ]; then
+  version=v$(cat version/version)
+elif [ "$#" -eq 1 ]; then
+  version=$1
+else
+  echo "version must be specified, either as an argument or an input" >&2
+  exit 1
+fi
+
+echo "$version" > ./release-name/release-name

--- a/tasks/scripts/build-release-notes
+++ b/tasks/scripts/build-release-notes
@@ -1,4 +1,12 @@
 #!/bin/bash
 
+LAST_COMMIT_SHA = $(cat concourse/.git/ref)
+
 chmod +x release-me/releaseme
-./release-me/releaseme generate --github-token=$GITHUB_TOKEN --github-owner=concourse --github-repo=concourse > built-notes/notes.md
+./release-me/releaseme generate \
+  --github-token=$GITHUB_TOKEN \
+  --github-owner=concourse \
+  --github-repo=concourse \
+  --github-branch=$GITHUB_BRANCH \
+  --last-commit-SHA=$LAST_COMMIT_SHA \
+  > built-notes/notes.md

--- a/tasks/scripts/build-release-notes
+++ b/tasks/scripts/build-release-notes
@@ -1,14 +1,4 @@
 #!/bin/bash
 
-if [ -d version ]; then
-  version=v$(cat version/version)
-elif [ "$#" -eq 1 ]; then
-  version=$1
-else
-  echo "version must be specified, either as an argument or an input" >&2
-  exit 1
-fi
-
-echo "$version" > ./built-notes/release-name
-# if this fails, it's because we forgot to manually promote latest.md to $version.md
-cp release-notes/release-notes/"$version".md ./built-notes/notes.md
+chmod +x release-me/releaseme
+./release-me/releaseme generate --github-token=$GITHUB_TOKEN --github-owner=concourse --github-repo=concourse > built-notes/notes.md


### PR DESCRIPTION
A new `create-draft-release` job was added into the publish group of the release pipeline. This job is responsible for creating a draft release in the Concourse repository with a generated release note.

The release note is generated using the `release-me` CLI https://github.com/clarafu/release-me. It generates a release note using all the PRs merged after the last release of the current release branch and before the commit that has made it through the testing part of the pipeline. It can be used to generate a release note for release branches, where the last release it will use will be the latest release made on that release branch. For example, if I had a release/5.5.x branch and the latest release is 5.5.1, the release note generated will include all prs merged after the 5.5.1 release and before the last commit that has been successfully tested. 

The generated release note will include all the PR titles and optional descriptions and be split into multiple sections. It is possible for this job to fail if one of the prs that got merged in does not have the appropriate labels (which are used to split it into sections). 

This `create-draft-release` job will run for every commit that makes it through the testing part of the release pipeline and will create a new draft release for every commit (which is more like it will update the description for the draft release with the new pr). This will allow for the release anchor to then take a look at the generated draft release note and manually edit the release note within github. After they are happy with the release note, they can click the `ship-it` job which will then convert the draft release into a real release.