### PR TITLE
dev image: do not enable dns proxy

### DIFF
--- a/dockerfiles/dev/Dockerfile-v6
+++ b/dockerfiles/dev/Dockerfile-v6
@@ -71,9 +71,6 @@ RUN cd /src && \
 VOLUME /worker-state
 ENV CONCOURSE_WORK_DIR /worker-state
 
-# enable DNS proxy to support Docker's 127.x.x.x DNS server
-ENV CONCOURSE_GARDEN_DNS_PROXY_ENABLE true
-
 # set $PATH for convenience
 ENV PATH /usr/local/concourse/bin:${PATH}
 

--- a/overrides/docker-compose.ci-containerd.yml
+++ b/overrides/docker-compose.ci-containerd.yml
@@ -4,7 +4,11 @@ services:
   worker:
     environment:
       # configure a network range that doesn't overlap with the outer worker
-      CONCOURSE_GARDEN_NETWORK_POOL: '10.224.0.0/16'
+      CONCOURSE_CONTAINERD_NETWORK_POOL: '10.224.0.0/16'
 
       # prevent worker from dropping out if the outer worker is overloaded
       CONCOURSE_EPHEMERAL: 'false'
+
+      CONCOURSE_RUNTIME: containerd
+
+      CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE: 'true'

--- a/overrides/docker-compose.ci-guardian.yml
+++ b/overrides/docker-compose.ci-guardian.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  worker:
+    environment:
+      # configure a network range that doesn't overlap with the outer worker
+      CONCOURSE_GARDEN_NETWORK_POOL: '10.224.0.0/16'
+
+      # prevent worker from dropping out if the outer worker is overloaded
+      CONCOURSE_EPHEMERAL: 'false'
+
+      CONCOURSE_RUNTIME: guardian
+
+      CONCOURSE_GARDEN_DNS_PROXY_ENABLE: 'true'

--- a/tasks/scripts/downgrade-test
+++ b/tasks/scripts/downgrade-test
@@ -26,7 +26,7 @@ $inputs/ci/tasks/scripts/generate-keys
 # start with rc and set up
 docker-compose \
   -f docker-compose.yml \
-  -f $inputs/ci/overrides/docker-compose.ci.yml \
+  -f $inputs/ci/overrides/docker-compose.ci-guardian.yml \
   -f $inputs/ci/overrides/docker-compose.no-build.yml \
   up --no-build -d
 
@@ -46,7 +46,7 @@ docker-compose exec web concourse migrate --migrate-db-to-version $downgrade_to
 # downgrade and verify
 docker-compose \
   -f docker-compose.yml \
-  -f $inputs/ci/overrides/docker-compose.ci.yml \
+  -f $inputs/ci/overrides/docker-compose.ci-guardian.yml \
   -f $inputs/ci/overrides/docker-compose.no-build.yml \
   -f $inputs/ci/overrides/docker-compose.latest.yml \
   up --no-build -d
@@ -56,7 +56,7 @@ $inputs/ci/tasks/scripts/verify-upgrade-downgrade-pipeline
 # upgrade back and verify
 docker-compose \
   -f docker-compose.yml \
-  -f $inputs/ci/overrides/docker-compose.ci.yml \
+  -f $inputs/ci/overrides/docker-compose.ci-guardian.yml \
   -f $inputs/ci/overrides/docker-compose.no-build.yml \
   up --no-build -d
 

--- a/tasks/scripts/upgrade-test
+++ b/tasks/scripts/upgrade-test
@@ -26,7 +26,7 @@ $inputs/ci/tasks/scripts/generate-keys
 # start with latest release and set up
 docker-compose \
   -f docker-compose.yml \
-  -f $inputs/ci/overrides/docker-compose.ci.yml \
+  -f $inputs/ci/overrides/docker-compose.ci-guardian.yml \
   -f $inputs/ci/overrides/docker-compose.no-build.yml \
   -f $inputs/ci/overrides/docker-compose.latest.yml \
   up --no-build -d
@@ -43,7 +43,7 @@ $inputs/ci/tasks/scripts/create-upgrade-downgrade-pipeline
 # upgrade and verify
 docker-compose \
   -f docker-compose.yml \
-  -f $inputs/ci/overrides/docker-compose.ci.yml \
+  -f $inputs/ci/overrides/docker-compose.ci-guardian.yml \
   -f $inputs/ci/overrides/docker-compose.no-build.yml \
   up --no-build -d
 

--- a/tasks/scripts/with-docker-compose
+++ b/tasks/scripts/with-docker-compose
@@ -13,10 +13,12 @@ export CONCOURSE_DEV_TAG=$(cat dev-image/tag)
 export POSTGRES_TAG=$(cat postgres-image/tag)
 export CONCOURSE_KEYS=$PWD/keys
 
-DOCKER_COMPOSE_FLAGS="-f concourse/docker-compose.yml -f ci/overrides/docker-compose.ci.yml"
+DOCKER_COMPOSE_FLAGS=""
 
 if [ "$CONTAINERD" = "true" ]; then
-  DOCKER_COMPOSE_FLAGS="$DOCKER_COMPOSE_FLAGS -f concourse/hack/overrides/containerd.yml"
+  DOCKER_COMPOSE_FLAGS="-f concourse/docker-compose.yml -f ci/overrides/docker-compose.ci-containerd.yml"
+else
+  DOCKER_COMPOSE_FLAGS="-f concourse/docker-compose.yml -f ci/overrides/docker-compose.ci-guardian.yml"
 fi
 
 if [ "$BUILD" = "true" ]; then


### PR DESCRIPTION
`CONCOURSE_GARDEN_DNS_PROXY_ENABLE` is meant for use in a running worker backed by Guardian. It doesn't make
sense for it to be set by default in a Docker image.

This also does not make sense now that setting dns-proxy on containerd requires a different flag i.e. `CONCOURSE_CONTAINERD_DNS_PROXY_ENABLE`. 

Not changing this will break the integration tests for containerd on CI which run with concourse/dev after the new flags have been introduced in.