### PR TITLE
update terraform runtime selection logic

### DIFF
--- a/deployments/smoke/smoke.tf
+++ b/deployments/smoke/smoke.tf
@@ -18,13 +18,18 @@ variable "use_https" {
 }
 
 variable "image" {
-  type = string
+  type    = string
   default = "ubuntu-1804-bionic-v20181003"
 }
 
-variable "USE_CONTAINERD" {
+variable "ENABLE_CONTAINERD" {
   type    = bool
   default = false
+}
+
+variable "HAS_RUNTIME_FLAG" {
+  type    = bool
+  default = true
 }
 
 provider "google" {
@@ -135,7 +140,8 @@ data "template_file" "worker_conf" {
   template = file("systemd/smoke-worker.conf.tpl")
 
   vars = {
-    use_containerd = var.USE_CONTAINERD
+    enable_containerd = var.ENABLE_CONTAINERD
+    has_runtime_flag  = var.HAS_RUNTIME_FLAG
   }
 }
 

--- a/deployments/smoke/systemd/smoke-worker.conf.tpl
+++ b/deployments/smoke/systemd/smoke-worker.conf.tpl
@@ -3,7 +3,7 @@ Environment=CONCOURSE_WORK_DIR=/etc/concourse/work-dir
 Environment=CONCOURSE_TSA_PUBLIC_KEY=/etc/concourse/host_key.pub
 Environment=CONCOURSE_TSA_WORKER_PRIVATE_KEY=/etc/concourse/worker_key
 %{ if use_containerd ~}
-Environment=CONCOURSE_GARDEN_USE_CONTAINERD="true"
+Environment=CONCOURSE_RUNTIME=containerd
 %{ else ~}
 Environment=CONCOURSE_GARDEN_CONFIG=/etc/concourse/garden.ini
 %{ endif ~}

--- a/deployments/smoke/systemd/smoke-worker.conf.tpl
+++ b/deployments/smoke/systemd/smoke-worker.conf.tpl
@@ -2,8 +2,12 @@
 Environment=CONCOURSE_WORK_DIR=/etc/concourse/work-dir
 Environment=CONCOURSE_TSA_PUBLIC_KEY=/etc/concourse/host_key.pub
 Environment=CONCOURSE_TSA_WORKER_PRIVATE_KEY=/etc/concourse/worker_key
-%{ if use_containerd ~}
+%{ if enable_containerd ~}
+  %{~ if has_runtime_flag ~}
 Environment=CONCOURSE_RUNTIME=containerd
+  %{~ else ~}
+Environment=CONCOURSE_GARDEN_USE_CONTAINERD="true"
+  %{~ endif ~}
 %{ else ~}
 Environment=CONCOURSE_GARDEN_CONFIG=/etc/concourse/garden.ini
 %{ endif ~}

--- a/pipelines/branch.yml
+++ b/pipelines/branch.yml
@@ -4,6 +4,7 @@
 #   ((environment)): a name for the bosh-deployed drills testing environment
 #   ((admin_username)),
 #   ((admin_password)): credentials for the admin user
+#   ((compatibility_version)): different versions might require different env vars; 'dev', '6.5.0', etc
 #
 # the branch name must not have any funny characters, and must exist on the
 # following repos:
@@ -467,6 +468,7 @@ jobs:
       GCP_KEY: ((concourse_smoke_gcp_key))
       SSH_KEY: ((concourse_smoke_ssh_key))
       WORKSPACE: branch-((branch_name))
+      CONCOURSE_VERSION: ((compatibility_version))
   - task: smoke
     image: unit-image
     file: ci/tasks/smoke.yml

--- a/pipelines/drills.yml
+++ b/pipelines/drills.yml
@@ -4,6 +4,7 @@
 #   ((environment)): a name for the bosh-deployed drills testing environment
 #   ((admin_username)),
 #   ((admin_password)): credentials for the admin user
+#   ((compatibility_version)): different versions might require different env vars; 'dev', '6.5.0', etc
 #
 # the branch name must not have any funny characters, and must exist on the
 # following repos:
@@ -342,6 +343,7 @@ jobs:
       GCP_KEY: ((concourse_smoke_gcp_key))
       SSH_KEY: ((concourse_smoke_ssh_key))
       WORKSPACE: branch-((branch_name))
+      CONCOURSE_VERSION: ((compatibility_version))
   - task: smoke
     image: unit-image
     file: ci/tasks/smoke.yml

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -280,16 +280,19 @@ jobs:
     vars:
       branch_name: algorithm-v3
       environment: algorithm
+      compatibility_version: 6.0.0
   - set_pipeline: runtime-drills
     file: pipelines-and-tasks/pipelines/branch.yml
     vars:
       branch_name: master
       environment: runtime-drills
+      compatibility_version: dev
   - set_pipeline: set-zstd-drills-env
     file: pipelines-and-tasks/pipelines/branch.yml
     vars:
       branch_name: use_zstd
       environment: use-zstd
+      compatibility_version: 6.0.0
   - set_pipeline: enterprise-helm-chart
     file: concourse-for-k8s/ci/pipeline.yml
     vars:

--- a/pipelines/release-v6.yml
+++ b/pipelines/release-v6.yml
@@ -671,6 +671,8 @@ jobs:
       trigger: true
     - get: unit-image
     - get: ci
+  - load_var: concourse_version
+    file: version/version
   - task: terraform-smoke
     image: unit-image
     file: ci/tasks/terraform-smoke.yml
@@ -681,6 +683,7 @@ jobs:
       SSH_KEY: ((concourse_smoke_ssh_key))
       WORKSPACE: release-((release_minor))
       USE_HTTPS: ((bin_smoke_use_https))
+      CONCOURSE_VERSION: ((.:concourse_version))
   - task: smoke
     image: unit-image
     file: ci/tasks/smoke.yml
@@ -693,17 +696,19 @@ jobs:
   serial: true
   plan:
     - in_parallel:
-        - get: concourse
-          passed: [build-rc]
-          trigger: true
-        - get: version
-          passed: [build-rc]
-          trigger: true
-        - get: linux-rc-ubuntu
-          passed: [build-rc]
-          trigger: true
-        - get: unit-image
-        - get: ci
+      - get: concourse
+        passed: [build-rc]
+        trigger: true
+      - get: version
+        passed: [build-rc]
+        trigger: true
+      - get: linux-rc-ubuntu
+        passed: [build-rc]
+        trigger: true
+      - get: unit-image
+      - get: ci
+    - load_var: concourse_version
+      file: version/version
     - task: terraform-smoke
       image: unit-image
       file: ci/tasks/terraform-smoke.yml
@@ -714,7 +719,8 @@ jobs:
         SSH_KEY: ((concourse_smoke_ssh_key))
         DEPLOYMENT: smoke
         WORKSPACE: release-((release_minor))-containerd
-        TF_VAR_USE_CONTAINERD: "true"
+        TF_VAR_ENABLE_CONTAINERD: "true"
+        CONCOURSE_VERSION: ((.:concourse_version))
     - task: smoke
       image: unit-image
       file: ci/tasks/smoke.yml

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -622,6 +622,8 @@ jobs:
       trigger: true
     - get: unit-image
     - get: ci
+  - load_var: concourse_version
+    file: version/version
   - task: terraform-smoke
     image: unit-image
     file: ci/tasks/terraform-smoke.yml
@@ -632,6 +634,7 @@ jobs:
       SSH_KEY: ((concourse_smoke_ssh_key))
       WORKSPACE: release-((release_minor))
       USE_HTTPS: ((bin_smoke_use_https))
+      CONCOURSE_VERSION: ((.:concourse_version))
   - task: smoke
     image: unit-image
     file: ci/tasks/smoke.yml

--- a/tasks/scripts/terraform-smoke
+++ b/tasks/scripts/terraform-smoke
@@ -10,6 +10,29 @@ if [ -d linux-rc ]; then
   cp linux-rc/concourse-*.tgz $deployment_path/concourse.tgz
 fi
 
+# takes 2 semver of form x.y.z[-rc.123] and returns
+# 0: =
+# 1: <
+# 2: >
+cmp() {
+  # strip pre-release (-rc) or build (+123) from semver
+  v1=$(echo $1 | sed -e 's/[-+].*$//g')
+  v2=$(echo $2 | sed -e 's/[-+].*$//g')
+
+  if [[ $v1 == $v2 ]]; then
+    echo "0"
+    return
+  fi
+
+  # use the magic of sort to figure out which version is smaller
+  smaller=$(echo -e "$v1\n$v2" | sort -t "." -k 1,1 -k 2,2 -k 3,3 -g | head -n1)
+  if [[ $smaller == $v1 ]]; then
+    echo "1"
+    return
+  fi
+  echo "2"
+}
+
 cd $deployment_path
 
 echo "$GCP_KEY" > keys/gcp.json
@@ -17,6 +40,13 @@ echo "$GCP_KEY" > keys/gcp.json
 echo "$SSH_KEY" > keys/id_rsa
 chmod 0600 keys/id_rsa
 ssh-keygen -y -f keys/id_rsa > keys/id_rsa.pub
+
+if [[ $CONCOURSE_VERSION != "dev" ]]; then
+  res=$(cmp $CONCOURSE_VERSION "6.5.0")
+  case $res in  # <
+    1) TF_VAR_HAS_RUNTIME_FLAG="false";;
+  esac
+fi
 
 terraform init
 

--- a/tasks/terraform-smoke.yml
+++ b/tasks/terraform-smoke.yml
@@ -11,7 +11,10 @@ params:
   SSH_KEY:
   WORKSPACE: default
   USE_HTTPS: 'true'
-  TF_VAR_USE_CONTAINERD: "false"
+  CONCOURSE_VERSION: "dev"
+  # variables consumed by terraform and their default values
+  # TF_VAR_ENABLE_CONTAINERD: "false"
+  # TF_VAR_HAS_RUNTIME_FLAG: "true"
 
 inputs:
 - name: concourse


### PR DESCRIPTION
~~CONCOURSE_USE_CONTAINERD has been replaced by CONCOURSE_RUNTIME. This unfortunately is going to break the `bin-smoke-containerd` test for 6.x pipelines from 6.4 and below. containerd is experimental in those releases and the job will be paused until we figure out a nice way to support the old 6.x pipelines and the current ones.~~

Update: The **non-breaking** way would be to pass the version number (`release_major`, `release_minor`) into the [release-v6.yml](https://github.com/concourse/ci/blob/3b5edb4a71908ea1c68aeb61f46f77385d4d98bb/pipelines/release-v6.yml#L704), and use that to select `CONCOURSE_USE_CONTAINERD` or `CONCOURSE_RUNTIME` accordingly.

I suggest doing that instead of the approach in this PR.