### PR TITLE
testflight: behaviour: add flakeAttempts flag

### DIFF
--- a/tasks/scripts/testflight
+++ b/tasks/scripts/testflight
@@ -12,4 +12,4 @@ go mod download
 
 go install github.com/onsi/ginkgo/ginkgo
 
-ginkgo -r -nodes=4 -race -keepGoing -slowSpecThreshold=15 ./testflight "$@"
+ginkgo -r -nodes=4 -race -keepGoing -slowSpecThreshold=15 -flakeAttempts=3 ./testflight "$@"


### PR DESCRIPTION
In order to better triage flakey tests, set the flakeAttempts flag to 3 on
the testflight suite. This will help us understand which specs are
flakey and prevent the job from failing due to them up to an extent.

It would help triage whether failures such as [this](https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/testflight-postgres/builds/182) are due to genuine failing tests or flakey tests.

