### PR TITLE
fix go1.15 windows builds failing

### DIFF
--- a/tasks/scripts/concourse-build-windows.ps1
+++ b/tasks/scripts/concourse-build-windows.ps1
@@ -23,7 +23,7 @@ if (Test-Path "final-version\version") {
 
 Push-Location concourse
   go install github.com/gobuffalo/packr/packr
-  packr build -o concourse.exe -ldflags "$ldflags" ./cmd/concourse
+  packr build -o concourse.exe -ldflags "$ldflags" -buildmode=exe ./cmd/concourse
   mv concourse.exe ..\concourse-windows
 Pop-Location
 


### PR DESCRIPTION
The additional flags go1.15 is passing to gcc seems to not like our code

https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/build-concourse/builds/307#L5f404a1e:4
https://github.com/golang/go/issues/40795