### PR TITLE
docker compose containerd legacy

### DIFF
--- a/deployments/smoke/smoke.tf
+++ b/deployments/smoke/smoke.tf
@@ -12,11 +12,6 @@ variable "region" {
   default = "us-central1"
 }
 
-variable "use_https" {
-  type    = bool
-  default = true
-}
-
 variable "image" {
   type    = string
   default = "ubuntu-1804-bionic-v20181003"
@@ -130,7 +125,6 @@ data "template_file" "web_conf" {
 
   vars = {
     instance_ip    = google_compute_address.smoke.address
-    use_https      = var.use_https
     admin_password = random_string.admin_password.result
     guest_password = random_string.guest_password.result
   }
@@ -219,7 +213,7 @@ resource "null_resource" "rerun" {
 }
 
 output "instance_url" {
-  value = var.use_https ? "https://${google_compute_address.smoke.address}.xip.io" : "http://${google_compute_address.smoke.address}:8080"
+  value = "https://${google_compute_address.smoke.address}.xip.io"
 }
 
 output "admin_password" {

--- a/deployments/smoke/systemd/smoke-web.conf.tpl
+++ b/deployments/smoke/systemd/smoke-web.conf.tpl
@@ -2,15 +2,11 @@
 Environment=CONCOURSE_SESSION_SIGNING_KEY=/etc/concourse/session_signing_key
 Environment=CONCOURSE_TSA_HOST_KEY=/etc/concourse/host_key
 Environment=CONCOURSE_TSA_AUTHORIZED_KEYS=/etc/concourse/authorized_worker_keys
-%{ if use_https ~}
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 Environment=CONCOURSE_EXTERNAL_URL=https://${instance_ip}.xip.io
 Environment=CONCOURSE_TLS_BIND_PORT=443
 Environment=CONCOURSE_ENABLE_LETS_ENCRYPT=true
 Environment=CONCOURSE_LETS_ENCRYPT_ACME_URL=https://acme-staging-v02.api.letsencrypt.org/directory
-%{ else ~}
-Environment=CONCOURSE_EXTERNAL_URL=http://${instance_ip}:8080
-%{ endif ~}
 Environment=CONCOURSE_POSTGRES_USER=concourse
 Environment=CONCOURSE_POSTGRES_DATABASE=concourse
 Environment=CONCOURSE_POSTGRES_SOCKET=/var/run/postgresql

--- a/overrides/docker-compose.ci-containerd-legacy.yml
+++ b/overrides/docker-compose.ci-containerd-legacy.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  worker:
+    environment:
+      # configure a network range that doesn't overlap with the outer worker
+      CONCOURSE_CONTAINERD_NETWORK_POOL: '10.224.0.0/16'
+
+      # prevent worker from dropping out if the outer worker is overloaded
+      CONCOURSE_EPHEMERAL: 'false'
+
+      CONCOURSE_GARDEN_USE_CONTAINERD: 'true'
+
+      CONCOURSE_GARDEN_DNS_PROXY_ENABLE: 'true'

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -257,7 +257,6 @@ jobs:
       release_minor: "5.5"
       latest_release: "5.5"
       concourse_smoke_deployment_name: "concourse-smoke-5-5"
-      bin_smoke_use_https: "true"
       end_of_general_support: "2020-07-31"
       has_runtime_flag: "false"
   - set_pipeline: release-6.3.x
@@ -267,7 +266,6 @@ jobs:
       release_minor: "6.3"
       latest_release: "6.2"
       concourse_smoke_deployment_name: "concourse-smoke-6-3"
-      bin_smoke_use_https: "true"
       has_runtime_flag: "false"
   - set_pipeline: release-6.5.x
     file: pipelines-and-tasks/pipelines/release-v6.yml
@@ -276,7 +274,6 @@ jobs:
       release_minor: "6.5"
       latest_release: "6.4"
       concourse_smoke_deployment_name: "concourse-smoke-6-5"
-      bin_smoke_use_https: "true"
       has_runtime_flag: "true"
   - set_pipeline: enterprise-helm-chart
     file: concourse-for-k8s/ci/pipeline.yml

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -259,6 +259,7 @@ jobs:
       concourse_smoke_deployment_name: "concourse-smoke-5-5"
       bin_smoke_use_https: "true"
       end_of_general_support: "2020-07-31"
+      has_runtime_flag: "false"
   - set_pipeline: release-6.3.x
     file: pipelines-and-tasks/pipelines/release-v6.yml
     vars:
@@ -267,6 +268,7 @@ jobs:
       latest_release: "6.2"
       concourse_smoke_deployment_name: "concourse-smoke-6-3"
       bin_smoke_use_https: "true"
+      has_runtime_flag: "false"
   - set_pipeline: release-6.5.x
     file: pipelines-and-tasks/pipelines/release-v6.yml
     vars:
@@ -275,6 +277,7 @@ jobs:
       latest_release: "6.4"
       concourse_smoke_deployment_name: "concourse-smoke-6-5"
       bin_smoke_use_https: "true"
+      has_runtime_flag: "true"
   - set_pipeline: enterprise-helm-chart
     file: concourse-for-k8s/ci/pipeline.yml
     vars:

--- a/pipelines/release-v6.yml
+++ b/pipelines/release-v6.yml
@@ -5,6 +5,7 @@
 #                                       concourse matches the desired release version
 #   ((concourse_smoke_deployment_name)) a unique name for the smoke bosh deployment
 #   ((latest_release))                  the latest concourse/concourse tag for upgrade testing (choose this based on the patch release eg 5.5 for 5.5.x)
+#   ((has_runtime_flag))                whether the CONCOURSE_RUNTIME flag is supported by this version (determines how to deploy containerd-backed workers)
 #
 # the following git branches need to be created:
 #
@@ -286,7 +287,9 @@ jobs:
     image: unit-image
     privileged: true
     timeout: 1h
-    params: {CONTAINERD: true}
+    params:
+      CONTAINERD: true
+      HAS_RUNTIME_FLAG: ((has_runtime_flag))
     file: ci/tasks/docker-compose-testflight.yml
   on_failure: *failed-concourse
   on_error: *failed-concourse
@@ -684,6 +687,7 @@ jobs:
       WORKSPACE: release-((release_minor))
       USE_HTTPS: ((bin_smoke_use_https))
       CONCOURSE_VERSION: ((.:concourse_version))
+      TF_VAR_HAS_RUNTIME_FLAG: ((has_runtime_flag))
   - task: smoke
     image: unit-image
     file: ci/tasks/smoke.yml
@@ -720,6 +724,7 @@ jobs:
         DEPLOYMENT: smoke
         WORKSPACE: release-((release_minor))-containerd
         TF_VAR_ENABLE_CONTAINERD: "true"
+        TF_VAR_HAS_RUNTIME_FLAG: ((has_runtime_flag))
         CONCOURSE_VERSION: ((.:concourse_version))
     - task: smoke
       image: unit-image

--- a/tasks/docker-compose-testflight.yml
+++ b/tasks/docker-compose-testflight.yml
@@ -20,6 +20,7 @@ params:
   BUILD:
   CONTAINERD:
   DOWNLOAD_CLI: true
+  HAS_RUNTIME_FLAG: true
 
 run:
   path: ci/tasks/scripts/pass-release-notes-only-change

--- a/tasks/scripts/terraform-smoke
+++ b/tasks/scripts/terraform-smoke
@@ -10,29 +10,6 @@ if [ -d linux-rc ]; then
   cp linux-rc/concourse-*.tgz $deployment_path/concourse.tgz
 fi
 
-# takes 2 semver of form x.y.z[-rc.123] and returns
-# 0: =
-# 1: <
-# 2: >
-cmp() {
-  # strip pre-release (-rc) or build (+123) from semver
-  v1=$(echo $1 | sed -e 's/[-+].*$//g')
-  v2=$(echo $2 | sed -e 's/[-+].*$//g')
-
-  if [[ $v1 == $v2 ]]; then
-    echo "0"
-    return
-  fi
-
-  # use the magic of sort to figure out which version is smaller
-  smaller=$(echo -e "$v1\n$v2" | sort -t "." -k 1,1 -k 2,2 -k 3,3 -g | head -n1)
-  if [[ $smaller == $v1 ]]; then
-    echo "1"
-    return
-  fi
-  echo "2"
-}
-
 cd $deployment_path
 
 echo "$GCP_KEY" > keys/gcp.json
@@ -40,13 +17,6 @@ echo "$GCP_KEY" > keys/gcp.json
 echo "$SSH_KEY" > keys/id_rsa
 chmod 0600 keys/id_rsa
 ssh-keygen -y -f keys/id_rsa > keys/id_rsa.pub
-
-if [[ $CONCOURSE_VERSION != "dev" ]]; then
-  res=$(cmp $CONCOURSE_VERSION "6.5.0")
-  case $res in  # <
-    1) TF_VAR_HAS_RUNTIME_FLAG="false";;
-  esac
-fi
 
 terraform init
 

--- a/tasks/scripts/with-docker-compose
+++ b/tasks/scripts/with-docker-compose
@@ -17,6 +17,9 @@ DOCKER_COMPOSE_FLAGS=""
 
 if [ "$CONTAINERD" = "true" ]; then
   DOCKER_COMPOSE_FLAGS="-f concourse/docker-compose.yml -f ci/overrides/docker-compose.ci-containerd.yml"
+  if [ "$HAS_RUNTIME_FLAG" = "false" ]; then
+    DOCKER_COMPOSE_FLAGS="-f concourse/docker-compose.yml -f ci/overrides/docker-compose.ci-containerd-legacy.yml"
+  else
 else
   DOCKER_COMPOSE_FLAGS="-f concourse/docker-compose.yml -f ci/overrides/docker-compose.ci-guardian.yml"
 fi


### PR DESCRIPTION
It may be useful to read the commit messages on this one. @chenbh sorry we destroyed your delicate semver-comparing function in favor explicit static configuration.
- containerd-backed docker-compose workers in 6.3.x
- remove bin_smoke_use_https var -- this is a little bit of tech debt that's not really related to the PR, but it wouldn't hurt for somebody to look at
