### PR TITLE
Test upgrade/downgrade in PR pipeline

### DIFF
--- a/pipelines/prs.yml
+++ b/pipelines/prs.yml
@@ -61,6 +61,15 @@ resources:
   source:
     uri: https://github.com/concourse/ci
 
+- name: concourse-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: concourse/concourse
+    tag: latest
+    username: ((docker.username))
+    password: ((docker.password))
+
 - name: dev-image
   type: registry-image
   icon: docker
@@ -363,6 +372,96 @@ jobs:
     input_mapping: {concourse: built-concourse}
     params: {BUILD: true}
     tags: [pr]
+
+- name: upgrade
+  public: true
+  max_in_flight: 3
+  on_failure:
+    put: concourse-pr
+    inputs: [concourse-pr]
+    params: {path: concourse-pr, status: failure, context: upgrade}
+    tags: [pr]
+    get_params: {skip_download: true}
+  on_success:
+    put: concourse-pr
+    inputs: [concourse-pr]
+    params: {path: concourse-pr, status: success, context: upgrade}
+    tags: [pr]
+    get_params: {skip_download: true}
+  plan:
+  - in_parallel:
+    - get: concourse-pr
+      trigger: true
+      version: every
+      tags: [pr]
+    - get: concourse-image
+      params: {format: oci}
+      tags: [pr]
+    - get: postgres-image
+      params: {format: oci}
+      tags: [pr]
+    - get: ci
+  - put: concourse-status-update
+    resource: concourse-pr
+    inputs: [concourse-pr]
+    params: {path: concourse-pr, status: pending, context: upgrade}
+    tags: [pr]
+    get_params: {list_changed_files: true, skip_download: true}
+  - task: yarn-build
+    attempts: 3
+    file: ci/tasks/yarn-build.yml
+    input_mapping: {concourse: concourse-pr}
+    tags: [pr]
+  - task: upgrade-test
+    privileged: true
+    params: {BUILD: true}
+    input_mapping: {concourse: built-concourse}
+    file: ci/tasks/upgrade-test.yml
+
+- name: downgrade
+  public: true
+  max_in_flight: 3
+  on_failure:
+    put: concourse-pr
+    inputs: [concourse-pr]
+    params: {path: concourse-pr, status: failure, context: downgrade}
+    tags: [pr]
+    get_params: {skip_download: true}
+  on_success:
+    put: concourse-pr
+    inputs: [concourse-pr]
+    params: {path: concourse-pr, status: success, context: downgrade}
+    tags: [pr]
+    get_params: {skip_download: true}
+  plan:
+  - in_parallel:
+    - get: concourse-pr
+      trigger: true
+      version: every
+      tags: [pr]
+    - get: concourse-image
+      params: {format: oci}
+      tags: [pr]
+    - get: postgres-image
+      params: {format: oci}
+      tags: [pr]
+    - get: ci
+  - put: concourse-status-update
+    resource: concourse-pr
+    inputs: [concourse-pr]
+    params: {path: concourse-pr, status: pending, context: downgrade}
+    tags: [pr]
+    get_params: {list_changed_files: true, skip_download: true}
+  - task: yarn-build
+    attempts: 3
+    file: ci/tasks/yarn-build.yml
+    input_mapping: {concourse: concourse-pr}
+    tags: [pr]
+  - task: downgrade-test
+    privileged: true
+    params: {BUILD: true}
+    input_mapping: {concourse: built-concourse}
+    file: ci/tasks/downgrade-test.yml
 
 - name: baggageclaim
   public: true

--- a/tasks/downgrade-test.yml
+++ b/tasks/downgrade-test.yml
@@ -5,9 +5,13 @@ image_resource:
   type: registry-image
   source: {repository: concourse/unit}
 
+params:
+  BUILD:
+
 inputs:
 - name: concourse
 - name: ci
+  # Mandatory if BUILD != true
 - name: dev-image
   optional: true
 - name: concourse-image

--- a/tasks/downgrade-test.yml
+++ b/tasks/downgrade-test.yml
@@ -11,7 +11,7 @@ params:
 inputs:
 - name: concourse
 - name: ci
-  # Mandatory if BUILD != true
+  # Required if BUILD != true
 - name: dev-image
   optional: true
 - name: concourse-image

--- a/tasks/scripts/downgrade-test
+++ b/tasks/scripts/downgrade-test
@@ -14,8 +14,12 @@ start_docker
 [ -d concourse-image ] && docker load -i concourse-image/image.tar
 [ -d postgres-image ] && docker load -i postgres-image/image.tar
 
-export CONCOURSE_DEV_TAG=$(cat dev-image/tag)
-export CONCOURSE_LATEST_TAG=$(cat concourse-image/tag)
+[ -f dev-image/tag ] && export CONCOURSE_DEV_TAG=$(cat dev-image/tag)
+if [ -f concourse-image/tag ]; then
+  export CONCOURSE_LATEST_TAG=$(cat concourse-image/tag)
+else
+  export CONCOURSE_LATEST_TAG=latest
+fi
 
 cd concourse
 
@@ -23,12 +27,19 @@ cd concourse
 export CONCOURSE_KEYS=$PWD/keys
 $inputs/ci/tasks/scripts/generate-keys
 
+DOCKER_COMPOSE_FLAGS=" -f docker-compose.yml -f $inputs/ci/overrides/docker-compose.ci-guardian.yml"
+
 # start with rc and set up
-docker-compose \
-  -f docker-compose.yml \
-  -f $inputs/ci/overrides/docker-compose.ci-guardian.yml \
-  -f $inputs/ci/overrides/docker-compose.no-build.yml \
-  up --no-build -d
+if [ "$BUILD" = "true" ]; then
+  docker-compose \
+    $DOCKER_COMPOSE_FLAGS \
+    up --build -d
+else
+  docker-compose \
+    $DOCKER_COMPOSE_FLAGS \
+    -f $inputs/ci/overrides/docker-compose.no-build.yml \
+    up --no-build -d
+fi
 
 trap stop_docker_compose EXIT SIGTERM SIGINT
 function stop_docker_compose() {

--- a/tasks/scripts/downgrade-test
+++ b/tasks/scripts/downgrade-test
@@ -65,11 +65,16 @@ docker-compose \
 $inputs/ci/tasks/scripts/verify-upgrade-downgraded-pipeline-temporary
 
 # upgrade back and verify
-docker-compose \
-  -f docker-compose.yml \
-  -f $inputs/ci/overrides/docker-compose.ci-guardian.yml \
-  -f $inputs/ci/overrides/docker-compose.no-build.yml \
-  up --no-build -d
+if [ "$BUILD" = "true" ]; then
+  docker-compose \
+    $DOCKER_COMPOSE_FLAGS \
+    up --no-build -d
+else
+  docker-compose \
+    $DOCKER_COMPOSE_FLAGS \
+    -f $inputs/ci/overrides/docker-compose.no-build.yml \
+    up --no-build -d
+fi
 
 $inputs/ci/tasks/scripts/verify-upgrade-downgrade-pipeline
 

--- a/tasks/scripts/downgrade-test
+++ b/tasks/scripts/downgrade-test
@@ -54,6 +54,12 @@ $inputs/ci/tasks/scripts/create-upgrade-downgrade-pipeline
 downgrade_to=$(docker run concourse/concourse:latest migrate --supported-db-version)
 docker-compose exec web concourse migrate --migrate-db-to-version $downgrade_to
 
+# this is needed so that the worker unregisters with the ATC.
+# docker-compose seems to recreate the web before recreating the worker,
+# and the worker is unable to unregister with the ATC since the ATC may
+# not be ready to receive requests.
+docker-compose stop worker
+
 # downgrade and verify
 docker-compose \
   $DOCKER_COMPOSE_FLAGS \
@@ -63,6 +69,12 @@ docker-compose \
 
 # This is done temporarily to bypass fly issue https://github.com/concourse/concourse/issues/5938
 $inputs/ci/tasks/scripts/verify-upgrade-downgraded-pipeline-temporary
+
+# this is needed so that the worker unregisters with the ATC.
+# docker-compose seems to recreate the web before recreating the worker,
+# and the worker is unable to unregister with the ATC since the ATC may
+# not be ready to receive requests.
+docker-compose stop worker
 
 # upgrade back and verify
 if [ "$BUILD" = "true" ]; then

--- a/tasks/scripts/downgrade-test
+++ b/tasks/scripts/downgrade-test
@@ -27,7 +27,7 @@ cd concourse
 export CONCOURSE_KEYS=$PWD/keys
 $inputs/ci/tasks/scripts/generate-keys
 
-DOCKER_COMPOSE_FLAGS=" -f docker-compose.yml -f $inputs/ci/overrides/docker-compose.ci-guardian.yml"
+DOCKER_COMPOSE_FLAGS="-f docker-compose.yml -f $inputs/ci/overrides/docker-compose.ci-guardian.yml"
 
 # start with rc and set up
 if [ "$BUILD" = "true" ]; then
@@ -56,8 +56,7 @@ docker-compose exec web concourse migrate --migrate-db-to-version $downgrade_to
 
 # downgrade and verify
 docker-compose \
-  -f docker-compose.yml \
-  -f $inputs/ci/overrides/docker-compose.ci-guardian.yml \
+  $DOCKER_COMPOSE_FLAGS \
   -f $inputs/ci/overrides/docker-compose.no-build.yml \
   -f $inputs/ci/overrides/docker-compose.latest.yml \
   up --no-build -d

--- a/tasks/scripts/generate-keys
+++ b/tasks/scripts/generate-keys
@@ -2,8 +2,8 @@
 
 set -e -u
 
-docker run -v ${CONCOURSE_KEYS}:/keys concourse/dev:${CONCOURSE_DEV_TAG} generate-key -t rsa -b 1024 -f /keys/session_signing_key
-docker run -v ${CONCOURSE_KEYS}:/keys concourse/dev:${CONCOURSE_DEV_TAG} generate-key -t ssh -b 1024 -f /keys/tsa_host_key
-docker run -v ${CONCOURSE_KEYS}:/keys concourse/dev:${CONCOURSE_DEV_TAG} generate-key -t ssh -b 1024 -f /keys/worker_key
+docker run -v ${CONCOURSE_KEYS}:/keys concourse/dev:${CONCOURSE_DEV_TAG:-latest} generate-key -t rsa -b 1024 -f /keys/session_signing_key
+docker run -v ${CONCOURSE_KEYS}:/keys concourse/dev:${CONCOURSE_DEV_TAG:-latest} generate-key -t ssh -b 1024 -f /keys/tsa_host_key
+docker run -v ${CONCOURSE_KEYS}:/keys concourse/dev:${CONCOURSE_DEV_TAG:-latest} generate-key -t ssh -b 1024 -f /keys/worker_key
 
 cp keys/worker_key.pub keys/authorized_worker_keys

--- a/tasks/scripts/upgrade-test
+++ b/tasks/scripts/upgrade-test
@@ -27,9 +27,12 @@ cd concourse
 export CONCOURSE_KEYS=$PWD/keys
 $inputs/ci/tasks/scripts/generate-keys
 
+DOCKER_COMPOSE_FLAGS="-f docker-compose.yml -f $inputs/ci/overrides/docker-compose.ci-guardian.yml"
+
 # start with latest release and set up
 docker-compose \
   $DOCKER_COMPOSE_FLAGS \
+  -f $inputs/ci/overrides/docker-compose.no-build.yml \
   -f $inputs/ci/overrides/docker-compose.latest.yml \
   up --no-build -d
 
@@ -41,8 +44,6 @@ function stop_docker_compose() {
 }
 
 $inputs/ci/tasks/scripts/create-upgrade-downgrade-pipeline
-
-DOCKER_COMPOSE_FLAGS=" -f docker-compose.yml -f $inputs/ci/overrides/docker-compose.ci-guardian.yml"
 
 # upgrade and verify
 if [ "$BUILD" = "true" ]; then

--- a/tasks/scripts/upgrade-test
+++ b/tasks/scripts/upgrade-test
@@ -14,8 +14,12 @@ start_docker
 [ -d concourse-image ] && docker load -i concourse-image/image.tar
 [ -d postgres-image ] && docker load -i postgres-image/image.tar
 
-export CONCOURSE_DEV_TAG=$(cat dev-image/tag)
-export CONCOURSE_LATEST_TAG=$(cat concourse-image/tag)
+[ -f dev-image/tag ] && export CONCOURSE_DEV_TAG=$(cat dev-image/tag)
+if [ -f concourse-image/tag ]; then
+  export CONCOURSE_LATEST_TAG=$(cat concourse-image/tag)
+else
+  export CONCOURSE_LATEST_TAG=latest
+fi
 
 cd concourse
 
@@ -25,9 +29,7 @@ $inputs/ci/tasks/scripts/generate-keys
 
 # start with latest release and set up
 docker-compose \
-  -f docker-compose.yml \
-  -f $inputs/ci/overrides/docker-compose.ci-guardian.yml \
-  -f $inputs/ci/overrides/docker-compose.no-build.yml \
+  $DOCKER_COMPOSE_FLAGS \
   -f $inputs/ci/overrides/docker-compose.latest.yml \
   up --no-build -d
 
@@ -40,12 +42,19 @@ function stop_docker_compose() {
 
 $inputs/ci/tasks/scripts/create-upgrade-downgrade-pipeline
 
+DOCKER_COMPOSE_FLAGS=" -f docker-compose.yml -f $inputs/ci/overrides/docker-compose.ci-guardian.yml"
+
 # upgrade and verify
-docker-compose \
-  -f docker-compose.yml \
-  -f $inputs/ci/overrides/docker-compose.ci-guardian.yml \
-  -f $inputs/ci/overrides/docker-compose.no-build.yml \
-  up --no-build -d
+if [ "$BUILD" = "true" ]; then
+  docker-compose \
+    $DOCKER_COMPOSE_FLAGS \
+    up --build -d
+else
+  docker-compose \
+    $DOCKER_COMPOSE_FLAGS \
+    -f $inputs/ci/overrides/docker-compose.no-build.yml \
+    up --no-build -d
+fi
 
 $inputs/ci/tasks/scripts/verify-upgrade-downgrade-pipeline
 

--- a/tasks/scripts/upgrade-test
+++ b/tasks/scripts/upgrade-test
@@ -45,6 +45,12 @@ function stop_docker_compose() {
 
 $inputs/ci/tasks/scripts/create-upgrade-downgrade-pipeline
 
+# this is needed so that the worker unregisters with the ATC.
+# docker-compose seems to recreate the web before recreating the worker,
+# and the worker is unable to unregister with the ATC since the ATC may
+# not be ready to receive requests.
+docker-compose stop worker
+
 # upgrade and verify
 if [ "$BUILD" = "true" ]; then
   docker-compose \

--- a/tasks/upgrade-test.yml
+++ b/tasks/upgrade-test.yml
@@ -5,9 +5,13 @@ image_resource:
   type: registry-image
   source: {repository: concourse/unit}
 
+params:
+  BUILD:
+
 inputs:
 - name: concourse
 - name: ci
+  # Required if BUILD != true
 - name: dev-image
   optional: true
 - name: concourse-image


### PR DESCRIPTION
I've seen PRs where the upgrade or downgrade path breaks things, but the existing PR tests don't capture these failures. Instead of waiting for these buggy PRs to be merged to find these errors, let's be proactive and test them prior to merging

As a side effect, this should also help with flakes like https://ci.concourse-ci.org/teams/main/pipelines/release-6.5.x/jobs/downgrade/builds/38#L5f5b83a3:288:289