### PR TITLE
properly cleanup namespaces when testing helm prs

### DIFF
--- a/tasks/scripts/k8s-lint-and-install
+++ b/tasks/scripts/k8s-lint-and-install
@@ -7,7 +7,7 @@ releasename="pr-$(cat concourse/.git/resource/pr)-$(head -c 6 concourse/.git/res
 function cleanup {
     sleep 10
     helm delete "$releasename" --namespace "$releasename" || true
-    kubectl delete --ignore-not-found=true namespace "$releasename-main"
+    kubectl delete --ignore-not-found=true namespace "$releasename"
 }
 trap cleanup EXIT
 
@@ -22,6 +22,7 @@ helm dependency update ./concourse
 helm install \
   "$releasename" \
   ./concourse \
+  --set=concourse.web.kubernetes.keepNamespaces=false \   # cleanup namespaces created by team secrets
   --namespace "$releasename" \
   --create-namespace
 # TODO: actually poke concourse to see that it's up. For now this just ensures helm doesn't exit 1 when installing


### PR DESCRIPTION
Probably should provide args similar to what the k8s topgun suite does, but for now I'm only concerned with leaking pvc/disks
https://github.com/concourse/concourse/blob/b5584f13bfe700b1c663a97f2e76afc9d406cd4a/topgun/k8s/k8s_suite_test.go#L283-L292

```sh
$k get pvc
NAME                                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
concourse-work-dir-pr-131-31ff9f-worker-0          Bound    pvc-0b7056df-8352-4f95-9fd2-f8fe4de2fc01   20Gi       RWO            standard       56d
concourse-work-dir-pr-131-31ff9f-worker-1          Bound    pvc-4a422325-8e62-414b-acca-bf6743288485   20Gi       RWO            standard       56d
concourse-work-dir-pr-131-c8c5d7-worker-0          Bound    pvc-75b2f048-6349-4b6e-8b62-618305b5d08d   20Gi       RWO            standard       65d
concourse-work-dir-pr-131-c8c5d7-worker-1          Bound    pvc-adfe5ca5-7bf7-42df-80eb-0f0cd224c53c   20Gi       RWO            standard       65d
concourse-work-dir-pr-133-3be5f9-worker-0          Bound    pvc-95e69d42-98ec-40b1-992d-a79f411d0812   20Gi       RWO            standard       64d
concourse-work-dir-pr-133-3be5f9-worker-1          Bound    pvc-643433c0-71ca-4845-8639-b4919bccdc5a   20Gi       RWO            standard       64d
concourse-work-dir-pr-134-c8c5d7-worker-0          Bound    pvc-74064f34-d2a8-4909-b1e0-b8c4a95fa826   20Gi       RWO            standard       59d
concourse-work-dir-pr-134-c8c5d7-worker-1          Bound    pvc-ade4b2ad-a404-47e9-8fe4-f62917df7691   20Gi       RWO            standard       59d
concourse-work-dir-pr-135-31ff9f-worker-0          Bound    pvc-5fdd484e-a90b-44c9-89c8-448ab2fa02ff   20Gi       RWO            standard       55d
data-pr-131-31ff9f-postgresql-0                    Bound    pvc-45bd2484-02ef-4f90-8384-84ad48369232   8Gi        RWO            standard       56d
data-pr-131-c8c5d7-postgresql-0                    Bound    pvc-dc9fb78f-dc03-4b45-b56d-8caf5b647d4c   8Gi        RWO            standard       65d
data-pr-133-3be5f9-postgresql-0                    Bound    pvc-3339df57-9b28-485b-bcfa-6945da30bb66   8Gi        RWO            standard       64d
data-pr-134-c8c5d7-postgresql-0                    Bound    pvc-c00353cc-2296-4b63-a4aa-c7b30e4c070a   8Gi        RWO            standard       59d
data-pr-135-31ff9f-postgresql-0                    Bound    pvc-10ce9285-399e-4000-a9f7-688182d37250   8Gi        RWO            standard       55d
data-pr-137-18d7d1-postgresql-0                    Bound    pvc-582c61aa-2528-4bf6-950f-a024a2d22c15   8Gi        RWO            standard       46d
data-pr-137-61da4b-postgresql-0                    Bound    pvc-975cfd10-17fc-48eb-a8f0-56c4c36da215   8Gi        RWO            standard       44d
data-pr-137-76f61d-postgresql-0                    Bound    pvc-4a9a24ef-141e-4aa1-a041-e2b3d4831b20   8Gi        RWO            standard       45d
data-pr-138-18d7d1-postgresql-0                    Bound    pvc-ed6683cd-1bdb-4a89-b2c0-df4d360dda8a   8Gi        RWO            standard       45d
data-pr-140-30c7fa-postgresql-0                    Bound    pvc-5b990419-1a9a-4ec2-a4f2-d3381b025627   8Gi        RWO            standard       38d
data-pr-141-05927d-postgresql-0                    Bound    pvc-4df09418-067f-4407-bc79-20f208d35846   8Gi        RWO            standard       34d
data-pr-142-05927d-postgresql-0                    Bound    pvc-241e04b8-1f46-4023-9083-98de474e0e60   8Gi        RWO            standard       32d
data-pr-143-0ded29-postgresql-0                    Bound    pvc-24c93039-b25c-4a8c-ba39-dc9edc9c7e34   8Gi        RWO            standard       24d
```