### PR TITLE
Update ci-unit

### DIFF
--- a/tasks/scripts/ci-unit
+++ b/tasks/scripts/ci-unit
@@ -3,4 +3,4 @@
 go get github.com/onsi/ginkgo/ginkgo
 go get github.com/onsi/gomega
 go get -d -v ./...
-ginkgo -r ci/tasks/scripts
+ginkgo -flakeAttempts=3 -r ci/tasks/scripts


### PR DESCRIPTION
Add flakeAttempts to deal with flakes
We observed a failure on 6.3 unit - https://ci.concourse-ci.org/teams/main/pipelines/release-6.3.x/jobs/unit/builds/126 that could be attributed to the test being flakey as the src hadn't changed.