### PR TITLE
Record versions of base resource types when generating release notes

### DIFF
--- a/tasks/build-release-notes.yml
+++ b/tasks/build-release-notes.yml
@@ -10,6 +10,7 @@ inputs:
 - name: ci
 - name: repo
 - name: version
+- name: resource-versions
 
 outputs:
 - name: built-notes

--- a/tasks/build-release-resource-versions.yml
+++ b/tasks/build-release-resource-versions.yml
@@ -1,0 +1,17 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/unit}
+
+inputs:
+- name: ci
+- name: linux-rc
+
+outputs:
+- name: resource-versions
+
+run:
+  path: ci/tasks/scripts/build-release-resource-versions
+

--- a/tasks/scripts/build-release-notes
+++ b/tasks/scripts/build-release-notes
@@ -12,3 +12,5 @@ chmod +x release-me/releaseme
   --last-commit-SHA=$LAST_COMMIT_SHA \
   --release-version=$RELEASE_VERSION \
   > built-notes/notes.md
+
+cat resource-versions/versions >> built-notes/notes.md

--- a/tasks/scripts/build-release-resource-versions
+++ b/tasks/scripts/build-release-resource-versions
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+echo "untar-ing rc"
+tar -zxf ./linux-rc/*.tgz concourse/resource-types --strip-components=1
+
+FILE=resource-versions/versions
+
+cat > $FILE <<EOF
+
+## 📦 Bundled resource types
+
+<details>
+
+EOF
+
+echo "parsing resource versions"
+for r in ./resource-types/*; do
+  name=$(basename $r)
+  version="v$(jq ".version" -r $r/resource_metadata.json)"
+  ghlink="https://github.com/concourse/$name-resource/releases/tag/$version"
+  echo "- $name: [$version]($ghlink)" >> $FILE
+done
+
+
+cat >> $FILE <<EOF
+
+</details>
+EOF


### PR DESCRIPTION
Keeping this as a PR to get everyone's thoughts on if this is actually useful. The idea is that at the end of the release notes, there's something that looks like:

## 📦 Bundled resource types

<details><summary>Base resource types</summary>
<p>

- bosh-io-release: [v1.0.3](https://github.com/concourse/bosh-io-release-resource/releases/tag/v1.0.3)
- bosh-io-stemcell: [v1.0.3](https://github.com/concourse/bosh-io-stemcell-resource/releases/tag/v1.0.3)
- cf: [v1.1.0](https://github.com/concourse/cf-resource/releases/tag/v1.1.0)
- docker-image: [v1.5.1](https://github.com/concourse/docker-image-resource/releases/tag/v1.5.1)
- git: [v1.10.0](https://github.com/concourse/git-resource/releases/tag/v1.10.0)
- github-release: [v1.5.0](https://github.com/concourse/github-release-resource/releases/tag/v1.5.0)
- hg: [v1.2.0](https://github.com/concourse/hg-resource/releases/tag/v1.2.0)
- mock: [v0.11.0](https://github.com/concourse/mock-resource/releases/tag/v0.11.0)
- pool: [v1.1.4](https://github.com/concourse/pool-resource/releases/tag/v1.1.4)
- registry-image: [v0.14.0](https://github.com/concourse/registry-image-resource/releases/tag/v0.14.0)
- s3: [v1.1.0](https://github.com/concourse/s3-resource/releases/tag/v1.1.0)
- semver: [v1.2.1](https://github.com/concourse/semver-resource/releases/tag/v1.2.1)
- time: [v1.4.0](https://github.com/concourse/time-resource/releases/tag/v1.4.0)
- tracker: [v1.0.3](https://github.com/concourse/tracker-resource/releases/tag/v1.0.3)
</p>
</details>