### PR TITLE
check if docker mounts have changed

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -271,6 +271,20 @@ jobs:
     file: ci/tasks/containerd-integration.yml
   on_failure: *failed-concourse
 
+- name: check-docker-mounts
+  public: true
+  max_in_flight: 1
+  plan:
+    - get: concourse
+      passed: [unit, dev-image]
+      trigger: true
+    - get: unit-image
+    - get: ci
+    - task: docker-mounts
+      image: unit-image
+      privileged: true
+      file: ci/tasks/docker-mounts.yml
+
 - name: testflight
   public: true
   max_in_flight: 2

--- a/tasks/docker-mounts.yml
+++ b/tasks/docker-mounts.yml
@@ -1,0 +1,17 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/unit}
+
+params:
+  KUBE_CONFIG:
+  RELEASE_NAME:
+
+inputs:
+- name: ci
+
+run:
+  path: ci/tasks/scripts/start-docker
+  args: [ci/tasks/scripts/docker-mounts]

--- a/tasks/docker-mounts.yml
+++ b/tasks/docker-mounts.yml
@@ -5,10 +5,6 @@ image_resource:
   type: registry-image
   source: {repository: concourse/unit}
 
-params:
-  KUBE_CONFIG:
-  RELEASE_NAME:
-
 inputs:
 - name: ci
 

--- a/tasks/scripts/docker-mounts
+++ b/tasks/scripts/docker-mounts
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -e -x -u
+
+cat > expected_docker_mounts <<EOF
+proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
+tmpfs on /dev type tmpfs (rw,nosuid,size=65536k,mode=755)
+devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
+sysfs on /sys type sysfs (ro,nosuid,nodev,noexec,relatime)
+tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,relatime,mode=755)
+cgroup on /sys/fs/cgroup/cpuset type cgroup (ro,nosuid,nodev,noexec,relatime,cpuset)
+cgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (ro,nosuid,nodev,noexec,relatime,cpu,cpuacct)
+cgroup on /sys/fs/cgroup/blkio type cgroup (ro,nosuid,nodev,noexec,relatime,blkio)
+cgroup on /sys/fs/cgroup/memory type cgroup (ro,nosuid,nodev,noexec,relatime,memory)
+cgroup on /sys/fs/cgroup/devices type cgroup (ro,nosuid,nodev,noexec,relatime,devices)
+cgroup on /sys/fs/cgroup/freezer type cgroup (ro,nosuid,nodev,noexec,relatime,freezer)
+cgroup on /sys/fs/cgroup/perf_event type cgroup (ro,nosuid,nodev,noexec,relatime,perf_event)
+cgroup on /sys/fs/cgroup/net_cls,net_prio type cgroup (ro,nosuid,nodev,noexec,relatime,net_cls,net_prio)
+cgroup on /sys/fs/cgroup/hugetlb type cgroup (ro,nosuid,nodev,noexec,relatime,hugetlb)
+cgroup on /sys/fs/cgroup/pids type cgroup (ro,nosuid,nodev,noexec,relatime,pids)
+cgroup on /sys/fs/cgroup/rdma type cgroup (ro,nosuid,nodev,noexec,relatime,rdma)
+none on /sys/fs/cgroup/systemd type cgroup (ro,nosuid,nodev,noexec,relatime,xattr,name=systemd)
+mqueue on /dev/mqueue type mqueue (rw,nosuid,nodev,noexec,relatime)
+shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k)
+/dev/sdb on /etc/resolv.conf type ext4 (rw,relatime)
+/dev/sdb on /etc/hostname type ext4 (rw,relatime)
+/dev/sdb on /etc/hosts type ext4 (rw,relatime)
+devpts on /dev/console type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
+proc on /proc/bus type proc (ro,relatime)
+proc on /proc/fs type proc (ro,relatime)
+proc on /proc/irq type proc (ro,relatime)
+proc on /proc/sys type proc (ro,relatime)
+proc on /proc/sysrq-trigger type proc (ro,relatime)
+tmpfs on /proc/acpi type tmpfs (ro,relatime)
+tmpfs on /proc/kcore type tmpfs (rw,nosuid,size=65536k,mode=755)
+tmpfs on /proc/keys type tmpfs (rw,nosuid,size=65536k,mode=755)
+tmpfs on /proc/timer_list type tmpfs (rw,nosuid,size=65536k,mode=755)
+tmpfs on /proc/sched_debug type tmpfs (rw,nosuid,size=65536k,mode=755)
+tmpfs on /proc/scsi type tmpfs (ro,relatime)
+tmpfs on /sys/firmware type tmpfs (ro,relatime)
+EOF
+
+cat > expected_privileged_docker_mounts <<EOF
+proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
+tmpfs on /dev type tmpfs (rw,nosuid,size=65536k,mode=755)
+devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
+sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
+tmpfs on /sys/fs/cgroup type tmpfs (rw,nosuid,nodev,noexec,relatime,mode=755)
+cgroup on /sys/fs/cgroup/cpuset type cgroup (rw,nosuid,nodev,noexec,relatime,cpuset)
+cgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (rw,nosuid,nodev,noexec,relatime,cpu,cpuacct)
+cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blkio)
+cgroup on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,noexec,relatime,memory)
+cgroup on /sys/fs/cgroup/devices type cgroup (rw,nosuid,nodev,noexec,relatime,devices)
+cgroup on /sys/fs/cgroup/freezer type cgroup (rw,nosuid,nodev,noexec,relatime,freezer)
+cgroup on /sys/fs/cgroup/perf_event type cgroup (rw,nosuid,nodev,noexec,relatime,perf_event)
+cgroup on /sys/fs/cgroup/net_cls,net_prio type cgroup (rw,nosuid,nodev,noexec,relatime,net_cls,net_prio)
+cgroup on /sys/fs/cgroup/hugetlb type cgroup (rw,nosuid,nodev,noexec,relatime,hugetlb)
+cgroup on /sys/fs/cgroup/pids type cgroup (rw,nosuid,nodev,noexec,relatime,pids)
+cgroup on /sys/fs/cgroup/rdma type cgroup (rw,nosuid,nodev,noexec,relatime,rdma)
+none on /sys/fs/cgroup/systemd type cgroup (rw,nosuid,nodev,noexec,relatime,xattr,name=systemd)
+mqueue on /dev/mqueue type mqueue (rw,nosuid,nodev,noexec,relatime)
+shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k)
+/dev/sdb on /etc/resolv.conf type ext4 (rw,relatime)
+/dev/sdb on /etc/hostname type ext4 (rw,relatime)
+/dev/sdb on /etc/hosts type ext4 (rw,relatime)
+devpts on /dev/console type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
+EOF
+
+docker pull busybox
+docker run -it busybox mount | tail -n +2 > docker-mounts
+docker run -it --privileged busybox mount  | tail -n +2 > privileged-docker-mounts
+
+# Instructions in case of job failure
+cat <<EOF
+ This job checks whether the mount configuration in a regular and privileged Docker container have changed.
+ The mount configurations Concourse uses for containerd roughly follow Docker with some necessary exceptions. As a
+ result we don't check against the containerd mounts directly.
+
+ If this job fails:
+ 1. Find out why the changes were made in Docker https://github.com/moby/moby/
+ Some files to check:
+ https://github.com/moby/moby/blob/master/daemon/oci_linux.go
+ https://github.com/moby/moby/blob/master/oci/defaults.go
+ 2. Determine if changes need to made to the mount configurations Concourse uses with containerd
+ https://github.com/concourse/concourse/blob/master/worker/runtime/spec/mounts.go
+ 3. Finally update this file with the latest expected Docker mounts
+EOF
+
+diff -Ebw docker-mounts expected_docker_mounts
+diff -Ebw privileged-docker-mounts expected_privileged_docker_mounts

--- a/tasks/scripts/start-docker
+++ b/tasks/scripts/start-docker
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e -u
+
+source ci/tasks/scripts/docker-helpers.sh
+
+start_docker
+trap stop_docker EXIT SIGTERM SIGINT
+
+"$@"


### PR DESCRIPTION
 This job checks whether the mount configuration in a regular and privileged Docker container have changed from
 our expectations.

 The mount configurations Concourse uses for containerd roughly follow Docker with some necessary exceptions. As a
 result we don't check against the containerd mounts directly.

 If this job fails:
 1. Find out why the changes were made in Docker https://github.com/moby/moby/
 Some files to check:
 https://github.com/moby/moby/blob/master/daemon/oci_linux.go
 https://github.com/moby/moby/blob/master/oci/defaults.go
 2. Determine if changes need to made to the mount configurations Concourse uses with containerd
 https://github.com/concourse/concourse/blob/master/worker/runtime/spec/mounts.go
 3. Finally update this file with the latest expected Docker mounts

Signed-off-by: Muntasir Chowdhury <muntasir.mzc@gmail.com>