### PR TITLE
Separate PR pipeline for each release pipeline

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -39,20 +39,11 @@ groups:
 
 - name: k8s
   jobs:
-  - k8s-check-helm-params
-  - k8s-smoke
-  - k8s-topgun
+  - k8s-*
 
 - name: bosh
   jobs:
-  - bosh-bump
-  - bosh-smoke
-  - bosh-smoke-containerd
-  - bosh-topgun-core
-  - bosh-topgun-runtime
-  - bosh-topgun-both
-  - bosh-topgun-pcf
-  - bosh-check-props
+  - bosh-*
 
 - name: images
   jobs:

--- a/pipelines/prs.yml
+++ b/pipelines/prs.yml
@@ -1,3 +1,9 @@
+# the following vars must be specified:
+#
+#   ((pr_base_branch))      only PRs against this branch will be run
+#   ((dev_image_tag))       the tag to use for the dev image
+#   ((concourse_image_tag)) the tag to use for the concourse image for upgrade/downgrade
+
 ---
 resource_types:
 - name: bosh-deployment
@@ -9,7 +15,7 @@ resource_types:
   source: {repository: teliaoss/github-pr-resource}
 
 resources:
-- name: concourse-master
+- name: concourse-base
   type: git
   icon: github
   source:
@@ -21,6 +27,7 @@ resources:
   source:
     repository: concourse/concourse
     access_token: ((pull_requests_access_token))
+    base_branch: ((pr_base_branch))
 
 - name: validator
   type: github-release
@@ -40,14 +47,18 @@ resources:
   icon: docker
   source:
     repository: concourse/concourse
-    tag: latest
+    tag: ((concourse_image_tag))
     username: ((docker.username))
     password: ((docker.password))
 
 - name: dev-image
   type: registry-image
   icon: docker
-  source: {repository: concourse/dev}
+  source:
+    repository: concourse/dev
+    tag: ((dev_image_tag))
+    username: ((docker.username))
+    password: ((docker.password))
 
 - name: unit-image
   type: registry-image
@@ -81,7 +92,7 @@ jobs:
       trigger: true
       version: every
       tags: [pr]
-    - get: concourse-master
+    - get: concourse-base
       tags: [pr]
     - get: unit-image
       tags: [pr]

--- a/pipelines/prs.yml
+++ b/pipelines/prs.yml
@@ -1,6 +1,6 @@
 # the following vars must be specified:
 #
-#   ((pr_base_branch))      only PRs against this branch will be run
+#   ((branch))              only PRs against this branch will be run
 #   ((dev_image_tag))       the tag to use for the dev image
 #   ((concourse_image_tag)) the tag to use for the concourse image for upgrade/downgrade
 
@@ -20,6 +20,7 @@ resources:
   icon: github
   source:
     uri: https://github.com/concourse/concourse
+    branch: ((branch))
 
 - name: concourse-pr
   type: pull-request
@@ -27,7 +28,7 @@ resources:
   source:
     repository: concourse/concourse
     access_token: ((pull_requests_access_token))
-    base_branch: ((pr_base_branch))
+    base_branch: ((branch))
 
 - name: validator
   type: github-release

--- a/pipelines/prs.yml
+++ b/pipelines/prs.yml
@@ -22,38 +22,12 @@ resources:
     repository: concourse/concourse
     access_token: ((pull_requests_access_token))
 
-- name: baggageclaim-master
-  type: git
-  icon: github
-  source:
-    uri: https://github.com/concourse/baggageclaim
-
-- name: baggageclaim-pr
-  type: pull-request
-  icon: source-pull
-  source:
-    repository: concourse/baggageclaim
-    access_token: ((pull_requests_access_token))
-
-- name: docs-master
-  type: git
-  icon: github
-  source:
-    uri: https://github.com/concourse/docs
-
 - name: validator
   type: github-release
   icon: github
   source:
     owner: clarafu
     repository: release-me
-
-- name: docs-pr
-  type: pull-request
-  icon: source-pull
-  source:
-    repository: concourse/docs
-    access_token: ((pull_requests_access_token))
 
 - name: ci
   type: git
@@ -79,11 +53,6 @@ resources:
   type: registry-image
   icon: docker
   source: {repository: concourse/unit}
-
-- name: baggageclaim-ci
-  type: registry-image
-  icon: docker
-  source: {repository: concourse/baggageclaim-ci}
 
 - name: postgres-image
   type: registry-image
@@ -425,37 +394,6 @@ jobs:
     params: {BUILD: true}
     input_mapping: {concourse: built-concourse}
     file: ci/tasks/downgrade-test.yml
-
-- name: baggageclaim
-  public: true
-  on_failure:
-    put: baggageclaim-pr
-    params: {path: baggageclaim-pr, status: failure, context: unit}
-    tags: [pr]
-  on_success:
-    put: baggageclaim-pr
-    params: {path: baggageclaim-pr, status: success, context: unit}
-    tags: [pr]
-  plan:
-  - in_parallel:
-    - get: baggageclaim-pr
-      trigger: true
-      version: every
-      tags: [pr]
-    - get: baggageclaim-master
-      tags: [pr]
-    - get: baggageclaim-ci
-    - get: ci
-  - put: baggageclaim-pr
-    params: {path: baggageclaim-pr, status: pending, context: unit}
-    tags: [pr]
-  - task: unit-linux
-    image: baggageclaim-ci
-    privileged: true
-    timeout: 1h
-    file: baggageclaim-master/ci/unit-linux.yml
-    input_mapping: {baggageclaim: baggageclaim-pr}
-    tags: [pr]
 
 - name: docs
   public: true

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -262,6 +262,10 @@ jobs:
   - set_pipeline: prs
     team: contributor
     file: pipelines-and-tasks/pipelines/prs.yml
+    vars:
+      pr_base_branch: master
+      dev_image_tag: latest
+      concourse_image_tag: latest
   - set_pipeline: helm-prs
     file: pipelines-and-tasks/pipelines/helm-prs.yml
     vars:

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -35,6 +35,13 @@ resources:
   source:
     uri: https://github.com/pivotal/concourse-for-platform-automation.git
 
+- name: docs-ci
+  type: git
+  icon: github
+  source:
+    uri: https://github.com/concourse/docs
+    paths: [ci]
+
 - name: flight-attendant-ci
   type: git
   icon: github
@@ -238,6 +245,8 @@ jobs:
     trigger: true
   - get: concourse-for-k8s
     trigger: true
+  - get: docs-ci
+    trigger: true
   - get: flight-attendant-ci
     trigger: true
   - get: ft-ci
@@ -269,6 +278,12 @@ jobs:
       concourse_image_tag: latest
   - set_pipeline: baggageclaim
     file: baggageclaim-ci/ci/pipeline.yml
+  - set_pipeline: baggageclaim-prs
+    team: contributor
+    file: baggageclaim-ci/ci/prs-pipeline.yml
+  - set_pipeline: docs-prs
+    team: contributor
+    file: docs-ci/ci/prs-pipeline.yml
   - set_pipeline: dutyfree
     team: dutyfree
     file: resource-types-website-ci/ci/pipeline.yml

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -262,8 +262,9 @@ jobs:
   - set_pipeline: prs
     team: contributor
     file: pipelines-and-tasks/pipelines/prs.yml
-    vars:
+    instance_vars:
       pr_base_branch: master
+    vars:
       dev_image_tag: latest
       concourse_image_tag: latest
   - set_pipeline: helm-prs

--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -263,7 +263,7 @@ jobs:
     team: contributor
     file: pipelines-and-tasks/pipelines/prs.yml
     instance_vars:
-      pr_base_branch: master
+      branch: master
     vars:
       dev_image_tag: latest
       concourse_image_tag: latest

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -45,6 +45,7 @@ resource_types:
 groups:
 - name: develop
   jobs:
+  - set-prs-pipeline
   - unit
   - resource-types-images
   - dev-image
@@ -84,6 +85,21 @@ groups:
   - "*"
 
 jobs:
+- name: set-prs-pipeline
+  public: true
+  serial: true
+  plan:
+  - get: ci-pipelines
+    trigger: true
+  - set_pipeline: prs
+    file: ci-pipelines/pipelines/prs.yml
+    team: contributor
+    instance_vars:
+      pr_base_branch: release/((release_minor)).x
+    vars:
+      dev_image_tag: release-((release_minor))
+      concourse_image_tag: ((release_minor))
+
 - name: unit
   public: true
   serial: true
@@ -1213,6 +1229,14 @@ resources:
   source:
     uri: https://github.com/concourse/ci.git
     branch: master
+
+- name: ci-pipelines
+  type: git
+  icon: github
+  source:
+    uri: https://github.com/concourse/ci
+    paths:
+    - pipelines
 
 - name: concourse-docker
   type: git

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -95,7 +95,7 @@ jobs:
     file: ci-pipelines/pipelines/prs.yml
     team: contributor
     instance_vars:
-      pr_base_branch: release/((release_minor)).x
+      branch: release/((release_minor)).x
     vars:
       dev_image_tag: release-((release_minor))
       concourse_image_tag: ((release_minor))

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -61,16 +61,11 @@ groups:
 
 - name: k8s
   jobs:
-  - k8s-check-helm-params
-  - k8s-smoke
-  - k8s-topgun
+  - k8s-*
 
 - name: bosh
   jobs:
-  - bosh-bump
-  - bosh-smoke
-  - bosh-topgun
-  - bosh-check-props
+  - bosh-*
 
 - name: publish
   jobs:

--- a/tasks/check-migration-order.yml
+++ b/tasks/check-migration-order.yml
@@ -7,7 +7,7 @@ image_resource:
 
 inputs:
 - name: concourse-pr
-- name: concourse-master
+- name: concourse-base
 - name: ci
 
 run:

--- a/tasks/scripts/check-migration-order
+++ b/tasks/scripts/check-migration-order
@@ -1,15 +1,8 @@
 #!/bin/bash
 
 migrations_path=atc/db/migration/migrations/
-master_dir=concourse-master/$migrations_path
+base_dir=concourse-base/$migrations_path
 pr_dir=concourse-pr/$migrations_path
-
-target_branch=$(cat concourse-pr/.git/resource/base_name)
-[ $target_branch = 'master' ] || {
-  echo "skipping migration check because this PR does not target the 'master' branch"
-  echo "target branch: $target_branch"
-  exit 0
-}
 
 if grep skip-migrations-check concourse-pr/.git/resource/title >/dev/null; then
   echo "skipping migration check at PR's request"
@@ -17,26 +10,26 @@ if grep skip-migrations-check concourse-pr/.git/resource/title >/dev/null; then
   exit 0
 fi
 
-migrations_on_master=$(mktemp)
-find $master_dir -name '[0-9]*' -exec basename {} \; |
-  sort > "$migrations_on_master"
+migrations_on_base=$(mktemp)
+find $base_dir -name '[0-9]*' -exec basename {} \; |
+  sort > "$migrations_on_base"
 
 actual_pr_migrations=$(mktemp)
 find $pr_dir -name '[0-9]*' -exec basename {} \; |
   sort > "$actual_pr_migrations"
 
-unique_to_master=$(comm -23 "$migrations_on_master" "$actual_pr_migrations")
-[ -z "$unique_to_master" ] || {
+unique_to_base=$(comm -23 "$migrations_on_base" "$actual_pr_migrations")
+[ -z "$unique_to_base" ] || {
   echo "pr removed migrations:"
-  echo "$unique_to_master"
+  echo "$unique_to_base"
   echo "and prs cannot remove migrations."
   exit 1
 }
 
-new_on_pr=$(comm -13 "$migrations_on_master" "$actual_pr_migrations")
+new_on_pr=$(comm -13 "$migrations_on_base" "$actual_pr_migrations")
 
 expected_pr_migrations=$(mktemp)
-sort -n "$migrations_on_master" >> "$expected_pr_migrations"
+sort -n "$migrations_on_base" >> "$expected_pr_migrations"
 if [ -n "$new_on_pr" ]; then
   echo "$new_on_pr" >> "$expected_pr_migrations"
 fi
@@ -47,7 +40,7 @@ fi
 diff "$expected_pr_migrations" <(sort -n "$actual_pr_migrations") >/dev/null || {
   echo "pr added migrations:"
   echo "$new_on_pr"
-  echo "out of order with master."
-  echo "new migrations in a pr must be strictly newer than those on master."
+  echo "out of order with the base branch."
+  echo "new migrations in a pr must be strictly newer than those on the base branch."
   exit 1
 }


### PR DESCRIPTION
fixes #384 

The current PR pipeline runs for PRs to all branches, but uses the same dev image/concourse image for all of them. This causes issues with upgrade/downgrade consistently, but can also cause issues due to incompatibilities in the dev image (e.g. resource type differences).

This PR does a few things:
* move baggageclaim/docs PR flows to their own pipelines (that have been moved to their respective repositories)
  * https://github.com/concourse/baggageclaim/blob/37cff0ddad499bb2e73e3d6e4bc469e88c199d3f/ci/prs-pipeline.yml
  * https://github.com/concourse/docs/blob/706a0155018ff5c060fdd822581267a5af52f634/ci/prs-pipeline.yml
* set a PR pipeline for master and per release pipeline
  * these PR pipelines are grouped as an instance group with the branch as the only instance var
  * note: in the future, when we have proper PR automation (with `var_source` prototypes and dynamic `across`), we can still use a single instance group with instance vars `branch` and `pr_number`