### PR TITLE
Add release prefix to release names

### DIFF
--- a/deployments/bosh-smoke.yml
+++ b/deployments/bosh-smoke.yml
@@ -2,11 +2,11 @@
 name: ((deployment_name))
 
 releases:
-- name: concourse
+- name: ((release_prefix))-concourse
   version: latest
-- name: postgres
+- name: ((release_prefix))-postgres
   version: latest
-- name: bpm
+- name: ((release_prefix))-bpm
   version: latest
 
 instance_groups:
@@ -18,10 +18,10 @@ instance_groups:
   vm_type: test
   stemcell: xenial
   jobs:
-  - release: bpm
+  - release: ((release_prefix))-bpm
     name: bpm
 
-  - release: concourse
+  - release: ((release_prefix))-concourse
     name: web
     properties:
       log_level: debug
@@ -47,13 +47,13 @@ instance_groups:
         host_key: ((tsa_host_key))
         authorized_keys: [((worker_key.public_key))]
 
-  - release: concourse
+  - release: ((release_prefix))-concourse
     name: worker
     properties:
       worker_gateway:
         worker_key: ((worker_key))
 
-  - release: postgres
+  - release: ((release_prefix))-postgres
     name: postgres
     properties:
       databases:

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -847,6 +847,7 @@ jobs:
       - gcp-xenial-stemcell/*.tgz
       vars:
         deployment_name: concourse-smoke
+        release_prefix: bosh-smoke
   - task: discover-bosh-endpoint-info
     tags: [bosh]
     file: ci/tasks/discover-bosh-endpoint-info.yml
@@ -900,6 +901,7 @@ jobs:
       - gcp-xenial-stemcell/*.tgz
       vars:
         deployment_name: concourse-smoke-containerd
+        release_prefix: bosh-smoke-containerd
   - task: discover-bosh-endpoint-info
     tags: [bosh]
     file: ci/tasks/discover-bosh-endpoint-info.yml


### PR DESCRIPTION
The `bosh-smoke` and `bosh-smoke-containerd` tests were flaking because of lock contention for acquiring the lock to create the releases that are used in the smoke tests. The following link is an example of the build failure

https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/bosh-smoke-containerd/builds/102

```
selected worker: 48adc80d-5581-4a46-bb54-18c0ac44e4fb
Waiting for deployment lock Done
Using environment 'https://10.0.0.6:25555' as client 'admin'

 100.00% 63.63 MB/s 22s
Task 104017

Task 104017 | 15:07:16 | Extracting release: Extracting release (00:00:47)
Task 104017 | 15:08:04 | Verifying manifest: Verifying manifest (00:00:00)
Task 104017 | 15:08:15 | Error: Failed to acquire lock for lock:release:concourse uid: 531fba75-7ae9-442c-9445-5fd58a97e502. Locking task id is 104018, description: 'create release'

Task 104017 Started  Wed Jan 20 15:07:16 UTC 2021
Task 104017 Finished Wed Jan 20 15:08:15 UTC 2021
Task 104017 Duration 00:00:59
Task 104017 error
Could not upload release /tmp/build/put/concourse-release/concourse-6.7.4-dev.20210120T145902Z.commit.cfc5166.tgz: Uploading release file: Expected task '104017' to succeed but state is 'error'
```

This is probably happening because both the `bosh-smoke` and `bosh-smoke-containerd` tests run at the same time and they are both trying to create the release for the `concourse`, `postgres` and `bpm` releases that are specified in the bosh manifest. This pr adds a prefix to the release names that will help remove any lock contention between the bosh smoke and bosh smoke containerd tests for creating the releases.