### PR TITLE
Fix the fix for bosh smoke tests

### DIFF
--- a/deployments/bosh-smoke.yml
+++ b/deployments/bosh-smoke.yml
@@ -2,11 +2,11 @@
 name: ((deployment_name))
 
 releases:
-- name: ((release_prefix))-concourse
+- name: concourse
   version: latest
-- name: ((release_prefix))-postgres
+- name: postgres
   version: latest
-- name: ((release_prefix))-bpm
+- name: bpm
   version: latest
 
 instance_groups:
@@ -18,10 +18,10 @@ instance_groups:
   vm_type: test
   stemcell: xenial
   jobs:
-  - release: ((release_prefix))-bpm
+  - release: bpm
     name: bpm
 
-  - release: ((release_prefix))-concourse
+  - release: concourse
     name: web
     properties:
       log_level: debug
@@ -47,13 +47,13 @@ instance_groups:
         host_key: ((tsa_host_key))
         authorized_keys: [((worker_key.public_key))]
 
-  - release: ((release_prefix))-concourse
+  - release: concourse
     name: worker
     properties:
       worker_gateway:
         worker_key: ((worker_key))
 
-  - release: ((release_prefix))-postgres
+  - release: postgres
     name: postgres
     properties:
       databases:

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -850,7 +850,6 @@ jobs:
       - gcp-xenial-stemcell/*.tgz
       vars:
         deployment_name: concourse-smoke
-        release_prefix: bosh-smoke
   - task: discover-bosh-endpoint-info
     tags: [bosh]
     file: ci/tasks/discover-bosh-endpoint-info.yml
@@ -904,7 +903,6 @@ jobs:
       - gcp-xenial-stemcell/*.tgz
       vars:
         deployment_name: concourse-smoke-containerd
-        release_prefix: bosh-smoke-containerd
   - task: discover-bosh-endpoint-info
     tags: [bosh]
     file: ci/tasks/discover-bosh-endpoint-info.yml

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -817,7 +817,7 @@ jobs:
   - put: concourse-release-repo
     params: {repository: bumped-concourse-release-repo}
 
-- name: bosh-smoke
+- name: bosh-upload-releases
   public: true
   serial: true
   plan:
@@ -835,6 +835,51 @@ jobs:
     - get: bpm-release
       trigger: true
     - get: gcp-xenial-stemcell
+      trigger: true
+    - get: bbr-sdk-release
+      trigger: true
+    - get: vault-release
+      trigger: true
+    - get: credhub-release
+      trigger: true
+    - get: uaa-release
+      trigger: true
+    - get: bbr
+      trigger: true
+    - get: ci
+  - task: upload-releases
+    tags: [bosh]
+    file: ci/tasks/upload-releases.yml
+    image: unit-image
+    params:
+      BOSH_ENVIRONMENT: https://10.0.0.6:25555
+      BOSH_CA_CERT: ((testing_bosh_ca_cert))
+      BOSH_CLIENT: ((testing_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((testing_bosh_client.secret))
+
+- name: bosh-smoke
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    # these don't trigger, to ensure that the job gets triggered by
+    # concourse-release, which is unfortunately decoupled from the resource
+    # that we 'put' to.
+    - get: concourse
+      passed: [bosh-upload-releases]
+    - get: unit-image
+      passed: [bosh-upload-releases]
+    - get: concourse-release
+      passed: [bosh-upload-releases]
+      trigger: true
+    - get: postgres-release
+      passed: [bosh-upload-releases]
+      trigger: true
+    - get: bpm-release
+      passed: [bosh-upload-releases]
+      trigger: true
+    - get: gcp-xenial-stemcell
+      passed: [bosh-upload-releases]
       trigger: true
     - get: ci
   - put: smoke-deployment
@@ -877,15 +922,20 @@ jobs:
     # concourse-release, which is unfortunately decoupled from the resource
     # that we 'put' to.
     - get: concourse
-      passed: [bosh-bump]
+      passed: [bosh-upload-releases]
     - get: unit-image
+      passed: [bosh-upload-releases]
     - get: concourse-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: postgres-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bpm-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: gcp-xenial-stemcell
+      passed: [bosh-upload-releases]
       trigger: true
     - get: ci
   - put: smoke-deployment-containerd
@@ -931,25 +981,35 @@ jobs:
     # concourse-release, which is unfortunately decoupled from the resource
     # that we 'put' to.
     - get: concourse
-      passed: [bosh-bump]
+      passed: [bosh-upload-releases]
     - get: unit-image
+      passed: [bosh-upload-releases]
     - get: concourse-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: postgres-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bpm-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bbr-sdk-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: gcp-xenial-stemcell
+      passed: [bosh-upload-releases]
       trigger: true
     - get: vault-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: credhub-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: uaa-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bbr
+      passed: [bosh-upload-releases]
       trigger: true
     - get: ci
   - task: bosh-topgun
@@ -979,25 +1039,35 @@ jobs:
     # concourse-release, which is unfortunately decoupled from the resource
     # that we 'put' to.
     - get: concourse
-      passed: [bosh-bump]
+      passed: [bosh-upload-releases]
     - get: unit-image
+      passed: [bosh-upload-releases]
     - get: concourse-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: postgres-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bpm-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bbr-sdk-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: gcp-xenial-stemcell
+      passed: [bosh-upload-releases]
       trigger: true
     - get: vault-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: credhub-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: uaa-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bbr
+      passed: [bosh-upload-releases]
       trigger: true
     - get: ci
   - task: bosh-topgun
@@ -1027,25 +1097,35 @@ jobs:
     # concourse-release, which is unfortunately decoupled from the resource
     # that we 'put' to.
     - get: concourse
-      passed: [bosh-bump]
+      passed: [bosh-upload-releases]
     - get: unit-image
+      passed: [bosh-upload-releases]
     - get: concourse-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: postgres-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bpm-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bbr-sdk-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: gcp-xenial-stemcell
+      passed: [bosh-upload-releases]
       trigger: true
     - get: vault-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: credhub-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: uaa-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bbr
+      passed: [bosh-upload-releases]
       trigger: true
     - get: ci
   - task: bosh-topgun
@@ -1075,25 +1155,35 @@ jobs:
     # concourse-release, which is unfortunately decoupled from the resource
     # that we 'put' to.
     - get: concourse
-      passed: [bosh-bump]
+      passed: [bosh-upload-releases]
     - get: unit-image
+      passed: [bosh-upload-releases]
     - get: concourse-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: postgres-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bpm-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bbr-sdk-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: gcp-xenial-stemcell
+      passed: [bosh-upload-releases]
       trigger: true
     - get: vault-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: credhub-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: uaa-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bbr
+      passed: [bosh-upload-releases]
       trigger: true
     - get: ci
   - task: bosh-topgun

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -836,7 +836,7 @@ jobs:
   - put: concourse-release-repo
     params: {repository: bumped-concourse-release-repo}
 
-- name: bosh-smoke
+- name: bosh-upload-releases
   public: true
   serial: true
   plan:
@@ -857,6 +857,53 @@ jobs:
     - get: bpm-release
       trigger: true
     - get: gcp-xenial-stemcell
+      trigger: true
+    - get: bbr-sdk-release
+      trigger: true
+    - get: vault-release
+      trigger: true
+    - get: credhub-release
+      trigger: true
+    - get: uaa-release
+      trigger: true
+    - get: bbr
+      trigger: true
+    - get: ci
+  - task: upload-releases
+    tags: [bosh]
+    file: ci/tasks/upload-releases.yml
+    image: unit-image
+    params:
+      BOSH_ENVIRONMENT: https://10.0.0.6:25555
+      BOSH_CA_CERT: ((testing_bosh_ca_cert))
+      BOSH_CLIENT: ((testing_bosh_client.id))
+      BOSH_CLIENT_SECRET: ((testing_bosh_client.secret))
+
+- name: bosh-smoke
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    # these don't trigger, to ensure that the job gets triggered by
+    # concourse-release, which is unfortunately decoupled from the resource
+    # that we 'put' to.
+    - get: concourse
+      passed: [bosh-upload-releases]
+    - get: unit-image
+      passed: [bosh-upload-releases]
+    - get: version
+      passed: [bosh-upload-releases]
+    - get: concourse-release
+      passed: [bosh-upload-releases]
+      trigger: true
+    - get: postgres-release
+      passed: [bosh-upload-releases]
+      trigger: true
+    - get: bpm-release
+      passed: [bosh-upload-releases]
+      trigger: true
+    - get: gcp-xenial-stemcell
+      passed: [bosh-upload-releases]
       trigger: true
     - get: ci
   - put: smoke-deployment
@@ -900,28 +947,37 @@ jobs:
     # concourse-release, which is unfortunately decoupled from the resource
     # that we 'put' to.
     - get: concourse
-      passed: [bosh-bump]
+      passed: [bosh-upload-releases]
     - get: unit-image
-      passed: [bosh-bump]
+      passed: [bosh-upload-releases]
     - get: version
-      passed: [bosh-bump]
+      passed: [bosh-upload-releases]
     - get: concourse-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: postgres-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bpm-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bbr-sdk-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: gcp-xenial-stemcell
+      passed: [bosh-upload-releases]
       trigger: true
     - get: vault-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: credhub-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: uaa-release
+      passed: [bosh-upload-releases]
       trigger: true
     - get: bbr
+      passed: [bosh-upload-releases]
       trigger: true
     - get: ci
   - task: bosh-topgun

--- a/tasks/scripts/upload-releases
+++ b/tasks/scripts/upload-releases
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex -u
+
+bosh upload-release concourse-release/*.tgz
+bosh upload-release postgres-release/*.tgz
+bosh upload-release bpm-release/*.tgz

--- a/tasks/upload-releases.yml
+++ b/tasks/upload-releases.yml
@@ -1,0 +1,21 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/unit}
+
+params:
+  BOSH_ENVIRONMENT:
+  BOSH_CA_CERT:
+  BOSH_CLIENT:
+  BOSH_CLIENT_SECRET:
+
+inputs:
+- name: concourse-release
+- name: postgres-release
+- name: bpm-release
+- name: ci
+
+run:
+  path: ci/tasks/scripts/upload-releases


### PR DESCRIPTION
I recently added a fix to the `bosh-smoke` and `bosh-smoke-containerd` tests that broke the `smoke` tests in a different way. If we were to go with the original fix, we would need to untar each bosh release and rename the release names within a separate task and upload these renamed releases for the smoke tests to use. This seems a little hairy so instead I decided to revert those changes and have a job before any of the bosh tests run that will upload all the necessary releases first so that each bosh test job will no longer need to acquire the lock for uploading the releases.