### PR TITLE
Team tasks pipeline

### DIFF
--- a/pipelines/reconfigure.yml
+++ b/pipelines/reconfigure.yml
@@ -445,6 +445,8 @@ jobs:
       container_name: hush-house-web
       mem_threshold_mb: 1024
       mem_limit: 2Gi
+  - set_pipeline: team-tasks
+    file: pipelines-and-tasks/pipelines/team-tasks.yml
   on_failure: *notify
   on_error: *notify
 

--- a/pipelines/team-tasks.yml
+++ b/pipelines/team-tasks.yml
@@ -59,6 +59,14 @@ resources:
     location: "America/Toronto"
     days: [Monday, Tuesday, Wednesday, Thursday, Friday]
 
+- name: friday-morning
+  type: time
+  source:
+    start: 11:00 AM
+    stop: 11:30 AM
+    location: "America/Toronto"
+    days: [Friday]
+
 - name: lunch
   type: static-list-resource
   source:
@@ -69,6 +77,12 @@ resources:
   type: static-list-resource
   source:
     unique: standup
+    list: *members
+
+- name: retro
+  type: static-list-resource
+  source:
+    unique: retro
     list: *members
 
 jobs:
@@ -107,3 +121,23 @@ jobs:
     resource: standup
     params:
       previous: standup/item
+
+- name: retro-rotation
+  plan:
+  - get: friday-morning
+    trigger: true
+  - get: retro
+  - put: slack-message
+    params:
+      text_file: retro/item
+      text: |
+        $TEXT_FILE_CONTENT is running retro today! If they can't do it today someone else should volunteer.
+        1. <https://postfacto.vmware.com/retros/concourse|Everyone should open the retro board>. No need to screenshare, everyone sees the same thing.
+        2. Allow everyone 5-10mins to add items to the board.
+        2. Go through all action items and check off any completed items.
+        3. Start going through the items on the board. If you don't want to think about which item to pick you can press the right arrow on your keyboard to auto-select an item (goes through all greens, then yellows, then reds, saving the green with the most hearts for last). Add action items as you go.
+        4. Once the board is cleared and all action items recorded you may archive the retro board (Menu > Archive Retro)
+  - put: next-weeks-host
+    resource: retro
+    params:
+      previous: retro/item

--- a/pipelines/team-tasks.yml
+++ b/pipelines/team-tasks.yml
@@ -1,0 +1,74 @@
+resource_types:
+- name: slack-notification
+  type: registry-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+
+- name: static-list-resource
+  type: registry-image
+  source:
+    repository: taylorsilva/static-list-resource
+
+- name: cron-resource
+  type: docker-image
+  source:
+    repository: cftoolsmiths/cron-resource
+
+resources:
+- name: slack-message
+  type: slack-notification
+  source:
+    url: ((slack_hook))
+
+- name: first-day-of-month
+  type: cron-resource
+  source:
+    expression: "0 0 1 * *"
+    location: "America/New_York"
+    fire_immediately: true
+
+- name: members
+  type: static-list-resource
+  check_every: never
+  source:
+    list:
+      # Aidan
+      - "<@W013S2H8ABU>"
+      # Scott
+      - "<@W013B9SAXJT>"
+      # Daniel
+      - "<@W013QLP3YJZ>"
+      # Esteban
+      - "<@U01LJULP0LS>"
+      # Alex
+      - "<@W013S7H1JCT>"
+      # Rui
+      - "<@W012PK4PCR1>"
+      # Taylor
+      - "<@W011PN57Q8Y>"
+      # Muntasir
+      - "<@W011EC91F5L>"
+      # Navdeep
+      - "<@W013K986P7G>"
+      # Matthew
+      - "<@W013BA1CNMD>"
+      # Clara
+      - "<@W013B99CVU7>"
+
+
+jobs:
+- name: monthly-team-lunch
+  plan:
+  - get: first-day-of-month
+    trigger: true
+  - get: members
+  - put: slack-message
+    params:
+      text_file: members/item
+      text: |
+        $TEXT_FILE_CONTENT will organize this month's team lunch!
+        1. Set a date/time and create a calendar event
+        2. Think of something the team can do/watch (e.g. codenames)
+  - put: members
+    params:
+      previous: members/item

--- a/pipelines/team-tasks.yml
+++ b/pipelines/team-tasks.yml
@@ -1,3 +1,27 @@
+members: &members
+# Aidan
+- "<@W013S2H8ABU>"
+# Scott
+- "<@W013B9SAXJT>"
+# Daniel
+- "<@W013QLP3YJZ>"
+# Esteban
+- "<@U01LJULP0LS>"
+# Alex
+- "<@W013S7H1JCT>"
+# Rui
+- "<@W012PK4PCR1>"
+# Taylor
+- "<@W011PN57Q8Y>"
+# Muntasir
+- "<@W011EC91F5L>"
+# Navdeep
+- "<@W013K986P7G>"
+# Matthew
+- "<@W013BA1CNMD>"
+# Clara
+- "<@W013B99CVU7>"
+
 resource_types:
 - name: slack-notification
   type: registry-image
@@ -39,57 +63,13 @@ resources:
   type: static-list-resource
   source:
     unique: lunch
-    list:
-      # Aidan
-      - "<@W013S2H8ABU>"
-      # Scott
-      - "<@W013B9SAXJT>"
-      # Daniel
-      - "<@W013QLP3YJZ>"
-      # Esteban
-      - "<@U01LJULP0LS>"
-      # Alex
-      - "<@W013S7H1JCT>"
-      # Rui
-      - "<@W012PK4PCR1>"
-      # Taylor
-      - "<@W011PN57Q8Y>"
-      # Muntasir
-      - "<@W011EC91F5L>"
-      # Navdeep
-      - "<@W013K986P7G>"
-      # Matthew
-      - "<@W013BA1CNMD>"
-      # Clara
-      - "<@W013B99CVU7>"
+    list: *members
 
 - name: standup
   type: static-list-resource
   source:
     unique: standup
-    list:
-      # Aidan
-      - "<@W013S2H8ABU>"
-      # Scott
-      - "<@W013B9SAXJT>"
-      # Daniel
-      - "<@W013QLP3YJZ>"
-      # Esteban
-      - "<@U01LJULP0LS>"
-      # Alex
-      - "<@W013S7H1JCT>"
-      # Rui
-      - "<@W012PK4PCR1>"
-      # Taylor
-      - "<@W011PN57Q8Y>"
-      # Muntasir
-      - "<@W011EC91F5L>"
-      # Navdeep
-      - "<@W013K986P7G>"
-      # Matthew
-      - "<@W013BA1CNMD>"
-      # Clara
-      - "<@W013B99CVU7>"
+    list: *members
 
 jobs:
 - name: monthly-team-lunch

--- a/pipelines/team-tasks.yml
+++ b/pipelines/team-tasks.yml
@@ -98,11 +98,10 @@ jobs:
       text_file: standup/item
       text: |
         $TEXT_FILE_CONTENT is running standup today! If they can't do it today someone else should volunteer.
-        1. Join the zoom room <http://hangar.concourse-ci.org/> to start standup.
-        2. <https://project.concourse-ci.org/pull-requests|Open the PR's tab in cadet> and start screen sharing. Open all unassigned PR's. For each PR ask who wants to review it and assign them.
-        3. <https://project.concourse-ci.org/pairs|Go to the pairs tab>. Ask if anyone is sticking or soloing. Then hit "shuffle" and "apply".
-        4. Stop screensharing. Give your daily update and pass it on to someone else.
-        5. Last person does the countdown clap!
+        1. <https://project.concourse-ci.org/pull-requests|Open the PR's tab in cadet> and start screen sharing. Open all unassigned PR's. For each PR ask who wants to review it and assign them.
+        2. <https://project.concourse-ci.org/pairs|Go to the pairs tab>. Ask if anyone is sticking or soloing. Then hit "shuffle" and "apply".
+        3. Stop screensharing. Give your daily update and pass it on to someone else.
+        4. Last person does the countdown clap!
   - put: standup
     params:
       previous: standup/item

--- a/pipelines/team-tasks.yml
+++ b/pipelines/team-tasks.yml
@@ -1,3 +1,4 @@
+# This is a list of everyones slack id
 members: &members
 # Aidan
 - "<@W013S2H8ABU>"

--- a/pipelines/team-tasks.yml
+++ b/pipelines/team-tasks.yml
@@ -40,18 +40,20 @@ resource_types:
 
 resources:
 - name: slack-message
+  icon: slack
   type: slack-notification
   source:
     url: ((slack_hooks.concourse-private))
 
 - name: first-day-of-month
+  icon: calendar
   type: cron-resource
   source:
     expression: "0 0 1 * *"
     location: "America/Toronto"
-    fire_immediately: true
 
 - name: good-morning
+  icon: calendar
   type: time
   source:
     start: 8:00 AM
@@ -60,6 +62,7 @@ resources:
     days: [Monday, Tuesday, Wednesday, Thursday, Friday]
 
 - name: friday-morning
+  icon: calendar
   type: time
   source:
     start: 11:00 AM
@@ -68,18 +71,21 @@ resources:
     days: [Friday]
 
 - name: lunch
+  icon: format-list-bulleted-square
   type: static-list-resource
   source:
     unique: lunch
     list: *members
 
 - name: standup
+  icon: format-list-bulleted-square
   type: static-list-resource
   source:
     unique: standup
     list: *members
 
 - name: retro
+  icon: format-list-bulleted-square
   type: static-list-resource
   source:
     unique: retro
@@ -99,7 +105,7 @@ jobs:
         1. Set a date/time and create a calendar event
         2. Think of something the team can do/watch (e.g. codenames)
   - put: next-months-organizer
-    resourc: lunch
+    resource: lunch
     params:
       previous: lunch/item
 

--- a/pipelines/team-tasks.yml
+++ b/pipelines/team-tasks.yml
@@ -84,7 +84,8 @@ jobs:
         $TEXT_FILE_CONTENT will organize this month's team lunch!
         1. Set a date/time and create a calendar event
         2. Think of something the team can do/watch (e.g. codenames)
-  - put: lunch
+  - put: next-months-organizer
+    resourc: lunch
     params:
       previous: lunch/item
 
@@ -102,6 +103,7 @@ jobs:
         2. <https://project.concourse-ci.org/pairs|Go to the pairs tab>. Ask if anyone is sticking or soloing. Then hit "shuffle" and "apply".
         3. Stop screensharing. Give your daily update and pass it on to someone else.
         4. Last person does the countdown clap!
-  - put: standup
+  - put: tomorrows-standup-host
+    resource: standup
     params:
       previous: standup/item

--- a/pipelines/team-tasks.yml
+++ b/pipelines/team-tasks.yml
@@ -24,13 +24,21 @@ resources:
   type: cron-resource
   source:
     expression: "0 0 1 * *"
-    location: "America/New_York"
+    location: "America/Toronto"
     fire_immediately: true
 
-- name: members
-  type: static-list-resource
-  check_every: never
+- name: good-morning
+  type: time
   source:
+    start: 8:00 AM
+    stop: 9:00 AM
+    location: "America/Toronto"
+    days: [Monday, Tuesday, Wednesday, Thursday, Friday]
+
+- name: lunch
+  type: static-list-resource
+  source:
+    unique: lunch
     list:
       # Aidan
       - "<@W013S2H8ABU>"
@@ -55,20 +63,66 @@ resources:
       # Clara
       - "<@W013B99CVU7>"
 
+- name: standup
+  type: static-list-resource
+  source:
+    unique: standup
+    list:
+      # Aidan
+      - "<@W013S2H8ABU>"
+      # Scott
+      - "<@W013B9SAXJT>"
+      # Daniel
+      - "<@W013QLP3YJZ>"
+      # Esteban
+      - "<@U01LJULP0LS>"
+      # Alex
+      - "<@W013S7H1JCT>"
+      # Rui
+      - "<@W012PK4PCR1>"
+      # Taylor
+      - "<@W011PN57Q8Y>"
+      # Muntasir
+      - "<@W011EC91F5L>"
+      # Navdeep
+      - "<@W013K986P7G>"
+      # Matthew
+      - "<@W013BA1CNMD>"
+      # Clara
+      - "<@W013B99CVU7>"
 
 jobs:
 - name: monthly-team-lunch
   plan:
   - get: first-day-of-month
     trigger: true
-  - get: members
+  - get: lunch
   - put: slack-message
     params:
-      text_file: members/item
+      text_file: lunch/item
       text: |
         $TEXT_FILE_CONTENT will organize this month's team lunch!
         1. Set a date/time and create a calendar event
         2. Think of something the team can do/watch (e.g. codenames)
-  - put: members
+  - put: lunch
     params:
-      previous: members/item
+      previous: lunch/item
+
+- name: standup-rotation
+  plan:
+  - get: good-morning
+    trigger: true
+  - get: standup
+  - put: slack-message
+    params:
+      text_file: standup/item
+      text: |
+        $TEXT_FILE_CONTENT is running standup today! If they can't do it today someone else should volunteer.
+        1. Join the zoom room <http://hangar.concourse-ci.org/> to start standup.
+        2. <https://project.concourse-ci.org/pull-requests|Open the PR's tab in cadet> and start screen sharing. Open all unassigned PR's. For each PR ask who wants to review it and assign them.
+        3. <https://project.concourse-ci.org/pairs|Go to the pairs tab>. Ask if anyone is sticking or soloing. Then hit "shuffle" and "apply".
+        4. Stop screensharing. Give your daily update and pass it on to someone else.
+        5. Last person does the countdown clap!
+  - put: standup
+    params:
+      previous: standup/item

--- a/pipelines/team-tasks.yml
+++ b/pipelines/team-tasks.yml
@@ -10,7 +10,7 @@ resource_types:
     repository: taylorsilva/static-list-resource
 
 - name: cron-resource
-  type: docker-image
+  type: registry-image
   source:
     repository: cftoolsmiths/cron-resource
 

--- a/pipelines/team-tasks.yml
+++ b/pipelines/team-tasks.yml
@@ -42,7 +42,7 @@ resources:
 - name: slack-message
   type: slack-notification
   source:
-    url: ((slack_hook))
+    url: ((slack_hooks.concourse-private))
 
 - name: first-day-of-month
   type: cron-resource


### PR DESCRIPTION
This pipeline has two jobs:
- Rotate who organizes team lunch every month
- Rotate who runs standup everyday so @vito and @scottietremendous aren't always doing it!
- Rotate who runs retro every Friday

Not sure if there's a better way to do the rotating list thing. I made the resource a few weeks ago for the tutorial I'm slowly writing for the docs.