### PR TITLE
Rebuild and publish concourse images daily

### DIFF
--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -85,7 +85,7 @@ groups:
   - bump-cbd-versions
   - patch
   - discover-component-version
-  - update-images
+  - rebuild-images
 
 - name: all
   jobs:

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -85,6 +85,7 @@ groups:
   - bump-cbd-versions
   - patch
   - discover-component-version
+  - update-images
 
 - name: all
   jobs:
@@ -1342,6 +1343,8 @@ jobs:
     - get: version
       passed: [shipit]
     - get: linux-rc
+      passed: [shipit]
+    - get: linux-rc-ubuntu
       passed: [shipit]
     - get: concourse-docker
       trigger: true

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -1365,17 +1365,17 @@ jobs:
       output_mapping: {image: image-ubuntu}
       privileged: true
   - in_parallel:
-    - task: watsjs-ubuntu
+    - task: watsjs-smoke-ubuntu
       image: unit-image
       privileged: true
       timeout: 1h
-      file: ci/tasks/docker-compose-watsjs.yml
+      file: ci/tasks/docker-compose-watsjs-smoke.yml
       input_mapping: {dev-image: image-ubuntu}
-    - task: watsjs-alpine
+    - task: watsjs-smoke-alpine
       image: unit-image
       privileged: true
       timeout: 1h
-      file: ci/tasks/docker-compose-watsjs.yml
+      file: ci/tasks/docker-compose-watsjs-smoke.yml
       input_mapping: {dev-image: image-alpine}
   - load_var: image_version
     file: version/version

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -1340,6 +1340,9 @@ jobs:
   - in_parallel:
     - get: periodic-check
       trigger: true
+    - get: unit-image
+    - get: concourse
+      passed: [shipit]
     - get: version
       passed: [shipit]
     - get: linux-rc
@@ -1347,7 +1350,6 @@ jobs:
     - get: linux-rc-ubuntu
       passed: [shipit]
     - get: concourse-docker
-      trigger: true
     - get: builder
     - get: ci
   - in_parallel:
@@ -1362,6 +1364,19 @@ jobs:
       input_mapping: {linux-rc: linux-rc-ubuntu}
       output_mapping: {image: image-ubuntu}
       privileged: true
+  - in_parallel:
+    - task: watsjs-ubuntu
+      image: unit-image
+      privileged: true
+      timeout: 1h
+      file: ci/tasks/docker-compose-watsjs.yml
+      input_mapping: {dev-image: image-ubuntu}
+    - task: watsjs-alpine
+      image: unit-image
+      privileged: true
+      timeout: 1h
+      file: ci/tasks/docker-compose-watsjs.yml
+      input_mapping: {dev-image: image-alpine}
   - load_var: image_version
     file: version/version
   - in_parallel:

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -1333,7 +1333,7 @@ jobs:
     params:
       file: version/version
 
-- name: update-images
+- name: rebuild-images
   public: true
   serial: true
   plan:

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -1380,18 +1380,33 @@ jobs:
   - load_var: image_version
     file: version/version
   - in_parallel:
+    - task: alpine-date-tag
+      image: unit-image
+      file: ci/tasks/tag-version-with-date.yml
+      output_mapping: {date-tag: alpine-date-tag}
+      params:
+        VERSION: ((.:image_version))-alpine
+    - task: ubuntu-date-tag
+      image: unit-image
+      file: ci/tasks/tag-version-with-date.yml
+      output_mapping: {date-tag: ubuntu-date-tag}
+      params:
+        VERSION: ((.:image_version))-ubuntu
+  - in_parallel:
     - put: concourse-image
-      inputs: [image-alpine]
+      inputs: detect
       params:
         image: image-alpine/image.tar
         version: ((.:image_version))
         bump_aliases: true
+        additional_tags: alpine-date-tag/tag
     - put: concourse-image-ubuntu
-      inputs: [image-ubuntu]
+      inputs: detect
       params:
         image: image-ubuntu/image.tar
         version: ((.:image_version))
         bump_aliases: true
+        additional_tags: ubuntu-date-tag/tag
   on_failure: *failed-concourse
   on_error: *failed-concourse
 

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -1352,6 +1352,8 @@ jobs:
     - get: concourse-docker
     - get: builder
     - get: ci
+  - load_var: image_version
+    file: version/version
   - in_parallel:
     - task: build-alpine
       file: concourse-docker/ci/build-image.yml
@@ -1365,6 +1367,17 @@ jobs:
       output_mapping: {image: image-ubuntu}
       privileged: true
   - in_parallel:
+    - task: validate-binary-version-alpine
+      image: image-alpine
+      file: ci/tasks/validate-binary-version.yml
+      params:
+        VERSION: ((.:image_version))
+    - task: validate-binary-version-ubuntu
+      image: image-ubuntu
+      file: ci/tasks/validate-binary-version.yml
+      params:
+        VERSION: ((.:image_version))
+  - in_parallel:
     - task: watsjs-smoke-ubuntu
       image: unit-image
       privileged: true
@@ -1377,8 +1390,6 @@ jobs:
       timeout: 1h
       file: ci/tasks/docker-compose-watsjs-smoke.yml
       input_mapping: {dev-image: image-alpine}
-  - load_var: image_version
-    file: version/version
   - in_parallel:
     - task: alpine-date-tag
       image: unit-image

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -1332,6 +1332,51 @@ jobs:
     params:
       file: version/version
 
+- name: update-images
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: periodic-check
+      trigger: true
+    - get: version
+      passed: [shipit]
+    - get: linux-rc
+      passed: [shipit]
+    - get: concourse-docker
+      trigger: true
+    - get: builder
+    - get: ci
+  - in_parallel:
+    - task: build-alpine
+      file: concourse-docker/ci/build-image.yml
+      image: builder
+      output_mapping: {image: image-alpine}
+      privileged: true
+    - task: build-ubuntu
+      file: concourse-docker/ci/build-image.yml
+      image: builder
+      input_mapping: {linux-rc: linux-rc-ubuntu}
+      output_mapping: {image: image-ubuntu}
+      privileged: true
+  - load_var: image_version
+    file: version/version
+  - in_parallel:
+    - put: concourse-image
+      inputs: [image-alpine]
+      params:
+        image: image-alpine/image.tar
+        version: ((.:image_version))
+        bump_aliases: true
+    - put: concourse-image-ubuntu
+      inputs: [image-ubuntu]
+      params:
+        image: image-ubuntu/image.tar
+        version: ((.:image_version))
+        bump_aliases: true
+  on_failure: *failed-concourse
+  on_error: *failed-concourse
+
 resources:
 - name: concourse
   type: git
@@ -1840,6 +1885,7 @@ resources:
     regexp: "helm-version-(.*).txt"
 
 - name: periodic-check
+  icon: clock
   type: time
   source:
     interval: 24h

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -1352,6 +1352,8 @@ jobs:
     - get: concourse-docker
     - get: builder
     - get: ci
+    - get: trivy
+    - get: trivy-db
   - load_var: image_version
     file: version/version
   - in_parallel:
@@ -1366,17 +1368,25 @@ jobs:
       input_mapping: {linux-rc: linux-rc-ubuntu}
       output_mapping: {image: image-ubuntu}
       privileged: true
-  - in_parallel:
+  - in_parallel: # sanity checks
     - task: validate-binary-version-alpine
       image: image-alpine
       file: ci/tasks/validate-binary-version.yml
       params:
-        VERSION: ((.:image_version))
+        EXPECTED_VERSION: ((.:image_version))
     - task: validate-binary-version-ubuntu
       image: image-ubuntu
       file: ci/tasks/validate-binary-version.yml
       params:
-        VERSION: ((.:image_version))
+        EXPECTED_VERSION: ((.:image_version))
+    - task: scan-image-alpine
+      file: ci/tasks/scan-image.yml
+      image: trivy
+      input_mapping: {image: image-alpine}
+    - task: scan-image-ubuntu
+      file: ci/tasks/scan-image.yml
+      image: trivy
+      input_mapping: {image: image-ubuntu}
   - in_parallel:
     - task: watsjs-smoke-ubuntu
       image: unit-image

--- a/tasks/docker-compose-watsjs-smoke.yml
+++ b/tasks/docker-compose-watsjs-smoke.yml
@@ -1,0 +1,29 @@
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/unit}
+
+inputs:
+- name: concourse
+- name: ci
+- name: dev-image
+- name: postgres-image
+  optional: true
+
+caches:
+- path: gopath
+- path: concourse/web/wats/node_modules
+
+params:
+  RUNTIME: guardian
+  POSTGRES_IMAGE: postgres-image
+
+run:
+  path: ci/tasks/scripts/with-docker-compose
+  args:
+    - "ci/tasks/scripts/watsjs"
+    # remove --serial after dex serialization failure is fixed:
+    # https://github.com/concourse/concourse/issues/3890
+    - "--serial"
+    - "test/smoke.js"

--- a/tasks/tag-version-with-date.yml
+++ b/tasks/tag-version-with-date.yml
@@ -1,0 +1,19 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/unit}
+
+outputs:
+- name: date-tag
+
+params:
+  VERSION: ~
+
+run:
+  path: bash
+  args:
+    - -ce
+    - |
+      echo ${VERSION}-$(date +"%Y%m%d") > date-tag/tag

--- a/tasks/validate-binary-version.yml
+++ b/tasks/validate-binary-version.yml
@@ -1,0 +1,16 @@
+---
+platform: linux
+
+params:
+  EXPECTED_VERSION: ~
+
+run:
+  path: bash
+  args:
+    - -cex
+    - |
+      BINARY_VERSION=$(/usr/local/concourse/bin/concourse --version)
+
+      if [[ "$BINARY_VERSION" != "${EXPECTED_VERSION}" ]]; then
+        exit 1
+      fi


### PR DESCRIPTION
This PR tries to bring us closer to image security best practices by rebuilding the concourse image for all active release branches ~and all resource images~ daily. Following [bitnami's footsteps here](https://docs.bitnami.com/tutorials/bitnami-best-practices-hardening-containers/#daily-builds-and-release-process), this is what they currently do.

~The resource pipeline has two jobs added; `shipit` for fanning in and `update-images` to build and republish both images on based on the last published version.~

The release pipeline only adds one job, `rebuild-images`. It builds images the same way the `build-rc-image` job does and publishes using the same steps the `publish-image` job does. The job has some additions:
- Along with the regular tags (e.g. `7.2.0`,`7.2`, etc) the images are also pushed to a tag that includes the date the image was pushed. The date tag is in the format of `7.2.0-{alpine,ubuntu}-YYYYMMDD`. This will allow users to opt-out of using the rolling tags (regular semver tags) if they want to, while clearly showing how old the image they are using is. Bitnami also does this with their images.
- Before publishing, the watsjs smoke test is run against both images
- As a sanity check:
  - verify that both images contain the expected binary version by comparing the output of `concourse --version` to the version tag that the images will be pushed to
  - scan both images with trivy to ensure all packages were updated with all available fixes
