### PR TITLE
Remove hardcoding of dev-image repository

### DIFF
--- a/tasks/scripts/integration
+++ b/tasks/scripts/integration
@@ -12,34 +12,33 @@ start_docker
 
 image_ref () {
   dir=$1
-  repo=$2
 
   # note: tag must take precedence, since the digest returned by the
   # registry-image resource is not the same as the image id in the docker CLI.
   # the oci-build-task, however, gives a digest that can be used
   if [ -f "${dir}/tag" ]; then
-    echo "${repo}:$(cat ${dir}/tag)"
+    echo "$(cat ${dir}/repository):$(cat ${dir}/tag)"
   else
     cat ${dir}/digest
   fi
 }
 
 docker load -i dev-image/image.tar
-export TEST_CONCOURSE_DEV_IMAGE="$(image_ref dev-image concourse/dev)"
+export TEST_CONCOURSE_DEV_IMAGE="$(image_ref dev-image)"
 
 if [ -d concourse-image ]; then
   docker load -i concourse-image/image.tar
-  export TEST_CONCOURSE_LATEST_IMAGE="$(image_ref concourse-image concourse/concourse)"
+  export TEST_CONCOURSE_LATEST_IMAGE="$(image_ref concourse-image)"
 fi
 
 if [ -d postgres-image ]; then
   docker load -i postgres-image/image.tar
-  export TEST_POSTGRES_IMAGE="$(image_ref postgres-image postgres)"
+  export TEST_POSTGRES_IMAGE="$(image_ref postgres-image)"
 fi
 
 if [ -d vault-image ]; then
   docker load -i vault-image/image.tar
-  export TEST_VAULT_IMAGE="$(image_ref vault-image vault)"
+  export TEST_VAULT_IMAGE="$(image_ref vault-image)"
 fi
 
 cd concourse

--- a/tasks/scripts/with-docker-compose
+++ b/tasks/scripts/with-docker-compose
@@ -13,7 +13,7 @@ docker load -i "$POSTGRES_IMAGE/image.tar"
 # registry-image resource is not the same as the image id in the docker CLI.
 # the oci-build-task, however, gives a digest that can be used
 [ -f dev-image/digest ] && export CONCOURSE_DEV_IMAGE="$(cat dev-image/digest)"
-[ -f dev-image/tag ] && export CONCOURSE_DEV_IMAGE="concourse/dev:$(cat dev-image/tag)"
+[ -f dev-image/tag ] && export CONCOURSE_DEV_IMAGE="$(cat dev-image/repository):$(cat dev-image/tag)"
 export POSTGRES_TAG=$(cat "$POSTGRES_IMAGE/tag")
 export CONCOURSE_KEYS=$PWD/keys
 


### PR DESCRIPTION
With this hard coding in place, `testflight` and `integration` tests will always use the `dev-image` produced by concourse' own CI. This ensures that dev-images produced by others can be used by this task.