### PR TITLE
add image vulnerability scanning to release pipelines

### DIFF
--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -649,6 +649,7 @@ jobs:
       trigger: true
     - get: builder
     - get: ci
+    - get: trivy
   - in_parallel:
       fail_fast: true
       steps:
@@ -663,6 +664,16 @@ jobs:
           input_mapping: {linux-rc: linux-rc-ubuntu}
           output_mapping: {image: image-ubuntu}
           privileged: true
+  - in_parallel:
+      steps:
+        - task: scan-alpine
+          file: ci/scan-image.yml
+          image: trivy
+          input_mapping: {image: image-alpine}
+        - task: scan-ubuntu
+          file: ci/scan-image.yml
+          image: trivy
+          input_mapping: {image: image-ubuntu}
   - in_parallel:
       fail_fast: true
       steps:
@@ -1799,3 +1810,8 @@ resources:
   source:
     owner: clarafu
     repository: release-me
+
+- name: trivy
+  type: registry-image
+  source:
+    repository: aquasec/trivy

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -62,6 +62,7 @@ groups:
   - rc
   - build-rc
   - build-rc-image
+  - scan-rc-image
   - bin-smoke
   - bin-smoke-lts
 
@@ -408,11 +409,11 @@ jobs:
       passed: [build-rc-image]
       trigger: true
     - get: concourse-rc-image
-      passed: [build-rc-image]
+      passed: [scan-rc-image]
       params: {format: oci}
       trigger: true
     - get: concourse-rc-image-ubuntu
-      passed: [build-rc-image]
+      passed: [scan-rc-image]
       params: {format: oci}
       trigger: true
     - get: version
@@ -665,16 +666,6 @@ jobs:
           output_mapping: {image: image-ubuntu}
           privileged: true
   - in_parallel:
-      steps:
-        - task: scan-alpine
-          file: ci/scan-image.yml
-          image: trivy
-          input_mapping: {image: image-alpine}
-        - task: scan-ubuntu
-          file: ci/scan-image.yml
-          image: trivy
-          input_mapping: {image: image-ubuntu}
-  - in_parallel:
       fail_fast: true
       steps:
         - put: concourse-rc-image
@@ -689,6 +680,54 @@ jobs:
             additional_tags: version/version
   on_failure: *failed-concourse
   on_error: *failed-concourse
+
+- name: scan-rc-image
+  public: true
+  serial: true
+  plan:
+  - in_parallel:
+    - get: concourse-rc-image
+      passed: [build-rc-image]
+      params: {format: oci}
+      trigger: true
+    - get: concourse-rc-image-rootfs
+      resource: concourse-rc-image
+      passed: [build-rc-image]
+      params: {format: rootfs}
+      trigger: true
+    - get: concourse-rc-image-ubuntu
+      passed: [build-rc-image]
+      params: {format: oci}
+      trigger: true
+    - get: concourse-rc-image-ubuntu-rootfs
+      resource: concourse-rc-image-ubuntu
+      passed: [build-rc-image]
+      params: {format: rootfs}
+      trigger: true
+    - get: ci
+    - get: trivy
+      trigger: true
+    - get: trivy-db
+      trigger: true
+      params: {globs: [trivy-offline.db.tgz]}
+  - in_parallel:
+      steps:
+        - task: scan-alpine
+          file: ci/tasks/scan-image.yml
+          image: trivy
+          input_mapping: {image: concourse-rc-image}
+        - task: scan-ubuntu
+          file: ci/tasks/scan-image.yml
+          image: trivy
+          input_mapping: {image: concourse-rc-image-ubuntu}
+        - task: scan-resource-types-alpine
+          file: ci/tasks/scan-resource-types.yml
+          image: trivy
+          input_mapping: {image: concourse-rc-image-rootfs}
+        - task: scan-resource-types-ubuntu
+          file: ci/tasks/scan-resource-types.yml
+          image: trivy
+          input_mapping: {image: concourse-rc-image-ubuntu-rootfs}
 
 - name: bin-smoke
   public: true
@@ -1815,3 +1854,10 @@ resources:
   type: registry-image
   source:
     repository: aquasec/trivy
+
+- name: trivy-db
+  type: github-release
+  icon: database
+  source:
+    owner: aquasecurity
+    repository: trivy-db

--- a/pipelines/resources/template.yml
+++ b/pipelines/resources/template.yml
@@ -95,6 +95,57 @@ plan:
   params: {image: built-resource-image/image.tar}
 #@ end
 
+#@ def scan_task(distro):
+task: #@ "scan-" + distro
+image: trivy
+config:
+  platform: linux
+  inputs:
+  - name: #@ "resource-image-dev-" + distro
+    path: image
+  - name: trivy-db
+  run:
+    path: sh
+    args:
+    - -c
+    - |
+      mkdir db
+      tar -xzf trivy-db/trivy-offline.db.tgz -C ./db
+
+      trivy \
+        --cache-dir $(pwd) \
+        image \
+        --severity "HIGH,CRITICAL" \
+        --ignore-unfixed \
+        --exit-code 1 \
+        --input image/image.tar
+#@ end
+
+#@ def scan_image():
+name: scan-image
+on_failure: &failed-ci
+  put: notify
+  params:
+    mode: normal
+    alert_type: failed
+plan:
+- in_parallel:
+  - get: resource-repo
+  - get: resource-image-dev-alpine
+    passed: [build-alpine]
+    params: {format: oci}
+  - get: resource-image-dev-ubuntu
+    passed: [build-ubuntu]
+    params: {format: oci}
+  - get: trivy
+    trigger: true
+  - get: trivy-db
+    trigger: true
+    params: {globs: [trivy-offline.db.tgz]}
+- #@ scan_task("alpine")
+- #@ scan_task("ubuntu")
+#@ end
+
 #@ def extra_steps(distro):
   #@ if resource_name == "docker-image":
 - task: smoke-test
@@ -177,24 +228,22 @@ name: #@ "publish-" + bump
 plan:
 - in_parallel:
   - get: resource-repo
-    passed:
-    - build-alpine
-    - build-ubuntu
+    passed: [scan-image]
   - get: ci
   - get: release-me
   - get: resource-image-dev-alpine
-    passed: [build-alpine]
+    passed: [scan-image]
     params: {format: oci}
   - get: resource-image-dev-alpine-rootfs
     resource: resource-image-dev-alpine
-    passed: [build-alpine]
+    passed: [scan-image]
     params: {format: rootfs}
   - get: resource-image-dev-ubuntu
-    passed: [build-ubuntu]
+    passed: [scan-image]
     params: {format: oci}
   - get: resource-image-dev-ubuntu-rootfs
     resource: resource-image-dev-ubuntu
-    passed: [build-ubuntu]
+    passed: [scan-image]
     params: {format: rootfs}
   - get: version
     params:
@@ -315,6 +364,7 @@ plan:
 jobs:
 - #@ build_image("alpine")
 - #@ build_image("ubuntu")
+- #@ scan_image()
 - #@ validate_pr("alpine")
 - #@ validate_pr("ubuntu")
 - #@ publish_job("major")
@@ -360,6 +410,19 @@ resources:
   source:
     repository: concourse/golang-builder
     variant: bionic
+
+- name: trivy
+  type: registry-image
+  icon: docker
+  source:
+    repository: aquasec/trivy
+
+- name: trivy-db
+  type: github-release
+  icon: database
+  source:
+    owner: aquasecurity
+    repository: trivy-db
 
 - name: resource-repo
   type: git

--- a/tasks/scan-image.yml
+++ b/tasks/scan-image.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: aquasec/trivy}
+
+inputs:
+- name: ci
+- name: image
+
+run:
+  path: ci/tasks/scripts/scan-image

--- a/tasks/scan-resource-types.yml
+++ b/tasks/scan-resource-types.yml
@@ -11,4 +11,5 @@ inputs:
 - name: trivy-db
 
 run:
-  path: ci/tasks/scripts/scan-image
+  path: ci/tasks/scripts/scan-resource-types
+

--- a/tasks/scripts/scan-image
+++ b/tasks/scripts/scan-image
@@ -2,7 +2,16 @@
 
 set -e
 
-trivy image \
+echo "unpacking vulnerability db"
+cache_dir=`pwd`
+mkdir -p "${cache_dir}/db"
+tar -xzf trivy-db/trivy-offline.db.tgz -C "${cache_dir}/db"
+
+echo "scanning base os"
+trivy \
+  --cache-dir "${cache_dir}" \
+  --quiet \
+  image \
   --severity "HIGH,CRITICAL" \
   --ignore-unfixed \
   --exit-code 1 \

--- a/tasks/scripts/scan-image
+++ b/tasks/scripts/scan-image
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+trivy image \
+  --severity "HIGH,CRITICAL" \
+  --ignore-unfixed \
+  --exit-code 1 \
+  --input image/image.tar

--- a/tasks/scripts/scan-resource-types
+++ b/tasks/scripts/scan-resource-types
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -e
+
+echo "unpacking vulnerability db"
+cache_dir=`pwd`
+mkdir -p "${cache_dir}/db"
+tar -xzf trivy-db/trivy-offline.db.tgz -C "${cache_dir}/db"
+
+failed=""
+cd image/rootfs/usr/local/concourse/resource-types
+
+set +e
+
+for resource in *; do
+  echo -e "\nscanning ${resource}-resource:"
+
+  cd $resource
+  tar -xzf rootfs.tgz
+
+  trivy \
+    --cache-dir "$cache_dir" \
+    --quiet \
+    filesystem \
+    --severity "HIGH,CRITICAL" \
+    --ignore-unfixed \
+    --exit-code 1 \
+    --input .
+
+  if [ $? -ne 0 ]; then
+    failed="${failed}\n- ${resource}"
+  fi
+
+  cd ..
+done
+
+if [ $failed != "" ]; then
+  echo -e "the following resource-types failed the scan:$failed"
+  exit 1
+fi
+


### PR DESCRIPTION
- using https://github.com/aquasecurity/trivy since it seems to be the most popular scanner that supports CLI-only
- we can use the official `aquasec/trivy` image or the `bitnami/trivy` fork