### PR TITLE
Capture stemcell version in release pipelines

### DIFF
--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -1151,6 +1151,8 @@ jobs:
       passed: [create-draft-release]
     - get: uaa-release
       passed: [create-draft-release]
+    - get: gcp-xenial-stemcell
+      passed: [bosh-smoke, bosh-topgun]
   - put: version
     params: {file: final-version/version}
 
@@ -1168,20 +1170,41 @@ jobs:
         trigger: true
       - get: version
         passed: [shipit]
-    - task: discover-postgresql-version
-      file: ci/tasks/discover-component-version.yml
-      output_mapping: {component-version: postgresql-version}
-      params: {COMPONENT_NAME: "postgresql"}
-    - task: discover-helm-version
-      file: ci/tasks/discover-component-version.yml
-      output_mapping: {component-version: helm-version}
-      params: {COMPONENT_NAME: "helm"}
-    - put: resource-postgresql-version
-      inputs: [postgresql-version]
-      params: {file: "postgresql-version/postgresql-version-*.txt"}
-    - put: resource-helm-version
-      inputs: [helm-version]
-      params: {file: "helm-version/helm-version-*.txt"}
+      - get: gcp-xenial-stemcell
+        passed: [shipit]
+    - in_parallel:
+      - load_var: concourse-version
+        file: version/version
+      - load_var: stemcell-version
+        file: gcp-xenial-stemcell/version
+    - in_parallel:
+      - task: discover-postgresql-version
+        file: ci/tasks/discover-component-version.yml
+        output_mapping: {component-version: postgresql-version}
+        params:
+          COMPONENT_NAME: "postgresql"
+          CONCOURSE_VERSION: ((.:concourse-version))
+      - task: discover-helm-version
+        file: ci/tasks/discover-component-version.yml
+        output_mapping: {component-version: helm-version}
+        params:
+          COMPONENT_NAME: "helm"
+          CONCOURSE_VERSION: ((.:concourse-version))
+      - task: discover-stemcell-version
+        file: ci/tasks/discover-stemcell-version.yml
+        params:
+          CONCOURSE_VERSION: ((.:concourse-version))
+          STEMCELL_VERSION: ((.:stemcell-version))
+    - in_parallel:
+      - put: resource-postgresql-version
+        inputs: [postgresql-version]
+        params: {file: "postgresql-version/postgresql-version-*.txt"}
+      - put: resource-helm-version
+        inputs: [helm-version]
+        params: {file: "helm-version/helm-version-*.txt"}
+      - put: gcp-stemcell-version
+        inputs: [stemcell-version]
+        params: {file: "stemcell-version/stemcell-version-*.txt"}
 
 - name: publish-binaries
   serial: true
@@ -1837,6 +1860,14 @@ resources:
     bucket: concourse-components-version
     json_key: ((concourse_components_json_key))
     regexp: "helm-version-(.*).txt"
+
+- name: gcp-stemcell-version
+  type: gcs
+  icon: format-list-bulleted
+  source:
+    bucket: concourse-components-version
+    json_key: ((concourse_components_json_key))
+    regexp: "stemcell-version-(.*).txt"
 
 - name: periodic-check
   type: time

--- a/tasks/discover-component-version.yml
+++ b/tasks/discover-component-version.yml
@@ -5,24 +5,20 @@ image_resource:
   source: {repository: concourse/unit}
 
 inputs:
-  - name: version
+- name: version
 
 outputs:
-  - name: component-version
+- name: component-version
 
 params:
   COMPONENT_NAME: ~
+  CONCOURSE_VERSION:
 
 run:
   path: /bin/bash
   args:
     - -cex
     - |
-
-      if [[ -d ./version ]]; then
-        CONCOURSE_VERSION=$(cat ./version/version)
-      fi
-
       if [ $COMPONENT_NAME == "helm" ]; then
         helm version --template "{{.Version}}" > ./component-version/helm-version-${CONCOURSE_VERSION}.txt
       else

--- a/tasks/discover-stemcell-version.yml
+++ b/tasks/discover-stemcell-version.yml
@@ -1,0 +1,19 @@
+platform: linux
+
+image_resource:
+  type: registry-image
+  source: {repository: concourse/unit}
+
+outputs:
+- name: stemcell-version
+
+params:
+  STEMCELL_VERSION: ~
+  CONCOURSE_VERSION: ~
+
+run:
+  path: /bin/bash
+  args:
+    - -cex
+    - |
+      echo $STEMCELL_VERSION > ./stemcell-version/stemcell-version-${CONCOURSE_VERSION}.txt


### PR DESCRIPTION
When releasing an enterprise version of Concourse we need to know what
stemcell version we tested against. This commit captures that info and
saves it in gcs for use by the enterprise pipeline on runway.