### PR TITLE
Target Dockerfile stage that builds fly when building images in the pr pipeline

### DIFF
--- a/pipelines/prs.yml
+++ b/pipelines/prs.yml
@@ -195,6 +195,7 @@ jobs:
       params:
         CONTEXT: built-concourse
         IMAGE_ARG_base_image: dev-image/image.tar
+        TARGET: with-fly
       inputs: [{name: built-concourse}, {name: dev-image}]
       outputs: [{name: image}]
       caches: [{path: cache}]
@@ -344,6 +345,7 @@ jobs:
       params:
         CONTEXT: built-concourse
         IMAGE_ARG_base_image: dev-image/image.tar
+        TARGET: with-fly
       inputs: [{name: built-concourse}, {name: dev-image}]
       outputs: [{name: image}]
       caches: [{path: cache}]
@@ -413,6 +415,7 @@ jobs:
       params:
         CONTEXT: built-concourse
         IMAGE_ARG_base_image: dev-image/image.tar
+        TARGET: with-fly
       inputs: [{name: built-concourse}, {name: dev-image}]
       outputs: [{name: image}]
       caches: [{path: cache}]


### PR DESCRIPTION
Follow up to https://github.com/concourse/concourse/pull/7058, did a basic `grep 'image: oci-build-task'` and these were the only ones that used `concourse/Dockerfile`. The rest all used `ci/dockerfiles/*`, and `concourse-docker/Dockerfile`