### PR TITLE
Fix broken links to bundled resource types

### DIFF
--- a/tasks/scripts/build-release-notes
+++ b/tasks/scripts/build-release-notes
@@ -25,7 +25,7 @@ if [ -f resource-type-versions/versions.yml ]; then
 
 $(
   awk 'BEGIN {FS = ": "}; {
-    url = sprintf("https://github.com/concourse/%s/releases/tag/%s", $1, $2);
+    url = sprintf("https://github.com/concourse/%s-resource/releases/tag/%s", $1, $2);
     printf "- %s: [%s](%s)\n", $1, $2, url
   }' resource-type-versions/versions.yml
 )


### PR DESCRIPTION
This MR fixes broken links to bundled resource types in the release notes. Currently they are broken because `-resource` suffix is missing (e.g. https://github.com/concourse/concourse/releases/tag/v7.3.1).