### PR TITLE
add linux-ubuntu to the build binary file name

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -656,7 +656,7 @@ jobs:
         output_mapping: {concourse-tarball: concourse-linux-alpine}
       - task: concourse-linux-ubuntu
         image: golang-builder-image
-        params: {PLATFORM: linux}
+        params: {PLATFORM: linux-ubuntu}
         file: ci/tasks/concourse-build-linux.yml
         input_mapping: {concourse: built-concourse, resource-types: resource-types-ubuntu}
         output_mapping: {concourse-tarball: concourse-linux-ubuntu}

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -686,7 +686,7 @@ jobs:
         file: ci/tasks/concourse-build-linux.yml
         input_mapping: {concourse: built-concourse, resource-types: resource-types-ubuntu}
         output_mapping: {concourse-tarball: concourse-linux-ubuntu}
-        params: {PLATFORM: linux}
+        params: {PLATFORM: linux-ubuntu}
       - task: concourse-windows
         file: ci/tasks/concourse-build-windows.yml
         input_mapping: {concourse: built-concourse}

--- a/tasks/scripts/concourse-build
+++ b/tasks/scripts/concourse-build
@@ -14,6 +14,10 @@ fi
 export GOOS="${PLATFORM:-$(go env GOOS)}"
 export GOARCH="amd64"
 
+if [ "${PLATFORM}" = "linux" ] || [ "${PLATFORM}" = "linux-ubuntu" ]; then
+  export GOOS="linux"
+fi
+
 version="$(cat version/version)"
 
 final_version=""
@@ -63,7 +67,7 @@ pushd $output
     apt-get update && apt-get install -y zip
     zip "$archive" concourse
   else
-    archive=concourse-${version}.${GOOS}.${GOARCH}.tgz
+    archive=concourse-${version}.${PLATFORM}.${GOARCH}.tgz
     tar -czf "$archive" concourse
   fi
   shasum "$archive" > "${archive}.sha1"


### PR DESCRIPTION
Currently both linux and ubuntu file names are identical which can potentially
overwrite the file by `put:linux-rc` and `put:linux-rc-ubuntu` steps. To avoid it,
adding ubuntu to the binary file name and also match the file name pattern
defined in `linux-rc-ubuntu` resource.