### PR TITLE
Remove docker-compose standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Configuration files for BOSH- and terraform-managed deployments used in testing.
 A lot of Dockerfiles are used throughout the Concourse automation. Many of those are in the `/dockerfiles` folder.
 
 ## Overrides
-Overrides for `docker-compose`.
+Overrides for `docker compose`.
 
 ## Pipelines
 Pipeline definitions live here. Some highlights:

--- a/dockerfiles/unit/Dockerfile
+++ b/dockerfiles/unit/Dockerfile
@@ -43,11 +43,6 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 RUN apt-get update && apt-get -y install docker-ce
 
-# install Docker Compose
-RUN curl -L "https://github.com/docker/compose/releases/download/1.27.4/docker-compose-$(uname -s)-$(uname -m)" \
-      -o /usr/local/bin/docker-compose && \
-      chmod +x /usr/local/bin/docker-compose
-
 # install Chrome for Puppeteer (watsjs/upgrade/downgrade/smoke)
 RUN curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN add-apt-repository "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -1653,6 +1653,7 @@ resources:
   type: bosh-io-release
   icon: *release-icon
   source:
+    #TODO: migrate to https://github.com/cloudfoundry-community/vault-boshrelease ?
     repository: vito/vault-boshrelease
 
 - name: credhub-release

--- a/tasks/scripts/quickstart-smoke
+++ b/tasks/scripts/quickstart-smoke
@@ -9,7 +9,7 @@ start_docker
 # load in concourse/concourse-dev:latest
 [ -d concourse-rc-image ] && docker load -i concourse-rc-image/image.tar
 
-docker-compose -f docs/docker-compose.yml -f ci/overrides/docker-compose.latest-rc.yml up -d
+docker compose -f docs/docker-compose.yml -f ci/overrides/docker-compose.latest-rc.yml up -d
 
 # now run the watjs/smoke tests
 mkdir -p endpoint-info
@@ -22,7 +22,7 @@ popd
 ci/tasks/scripts/smoke
 
 pushd docs
-  docker-compose down
+  docker compose down
 popd
 
 stop_docker

--- a/tasks/scripts/testflight
+++ b/tasks/scripts/testflight
@@ -14,4 +14,4 @@ go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 
 ginkgo -r -nodes=4 --race --keep-going --poll-progress-after=15s --flake-attempts=3 ./testflight "$@"
 
-docker-compose logs > ../docker-compose.log
+docker compose logs > ../docker-compose.log

--- a/tasks/scripts/with-docker-compose
+++ b/tasks/scripts/with-docker-compose
@@ -21,15 +21,15 @@ DOCKER_COMPOSE_FLAGS="-f concourse/docker-compose.yml -f ci/overrides/docker-com
 
 ci/tasks/scripts/generate-keys
 
-docker-compose \
+docker compose \
   $DOCKER_COMPOSE_FLAGS \
   -f ci/overrides/docker-compose.no-build.yml \
   up --no-build -d
 
 trap stop_docker_compose EXIT SIGTERM SIGINT
 function stop_docker_compose() {
-  docker-compose -f concourse/docker-compose.yml logs > docker-compose.log
-  docker-compose -f concourse/docker-compose.yml down
+  docker compose -f concourse/docker-compose.yml logs > docker-compose.log
+  docker compose -f concourse/docker-compose.yml down
   stop_docker
 }
 


### PR DESCRIPTION
Using `docker compose` plugin instead, which has been around since 2020, so we're a bit behind the curve here.

Migrating looks like a complete drop-in replacement: https://docs.docker.com/compose/migrate/#command-line-flags-and-subcommands

Should merge after concourse/concourse#8946