### PR TITLE
fix: Update build-resource-types-image/run.sh

### DIFF
--- a/tasks/build-resource-types-image/run.sh
+++ b/tasks/build-resource-types-image/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -euo pipefail
 


### PR DESCRIPTION
Switch build-resource-types-image/run.sh to use sh instead of bash due to OCI Build Task not having bash