### PR TITLE
extend testing on windows

### DIFF
--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -140,7 +140,6 @@ jobs:
             image: unit-image
             file: ci/tasks/unit/task.yml
           - task: unit-windows
-            attempts: 3
             file: ci/tasks/unit-windows/task.yml
 
   - name: unit-yarn

--- a/pipelines/concourse.yml
+++ b/pipelines/concourse.yml
@@ -134,10 +134,14 @@ jobs:
           - get: unit-image
             trigger: true
           - get: ci
-      - task: unit
-        timeout: 1h
-        image: unit-image
-        file: ci/tasks/unit/task.yml
+      - timeout: 1h
+        in_parallel:
+          - task: unit
+            image: unit-image
+            file: ci/tasks/unit/task.yml
+          - task: unit-windows
+            attempts: 3
+            file: ci/tasks/unit-windows/task.yml
 
   - name: unit-yarn
     public: true

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -139,7 +139,6 @@ jobs:
             image: unit-image
             file: ci/tasks/unit/task.yml
           - task: unit-windows
-            attempts: 3
             file: ci/tasks/unit-windows/task.yml
 
   - name: unit-yarn

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -133,10 +133,14 @@ jobs:
           - get: periodic-check
             trigger: true
           - get: ci
-      - task: unit
-        timeout: 1h
-        image: unit-image
-        file: ci/tasks/unit/task.yml
+      - timeout: 1h
+        in_parallel:
+          - task: unit
+            image: unit-image
+            file: ci/tasks/unit/task.yml
+          - task: unit-windows
+            attempts: 3
+            file: ci/tasks/unit-windows/task.yml
 
   - name: unit-yarn
     public: true

--- a/tasks/unit-windows/run.ps1
+++ b/tasks/unit-windows/run.ps1
@@ -10,6 +10,6 @@ if ($LASTEXITCODE) { Throw "failed to determine Ginkgo version (exit code $LASTE
 go install "github.com/onsi/ginkgo/v2/ginkgo@$GinkgoVersion"
 if ($LASTEXITCODE) { Throw "Ginkgo installation failed (exit code $LASTEXITCODE)" }
 
-ginkgo -r -p ./go-archive
+ginkgo -r -p -flake-attempts=3 -race ./go-archive
 
 Exit $LastExitCode

--- a/tasks/unit-windows/run.ps1
+++ b/tasks/unit-windows/run.ps1
@@ -10,6 +10,7 @@ if ($LASTEXITCODE) { Throw "failed to determine Ginkgo version (exit code $LASTE
 go install "github.com/onsi/ginkgo/v2/ginkgo@$GinkgoVersion"
 if ($LASTEXITCODE) { Throw "Ginkgo installation failed (exit code $LASTEXITCODE)" }
 
+$env:CGO_ENABLED = 1
 ginkgo -r -p -flake-attempts=3 -race ./go-archive
 
 Exit $LastExitCode

--- a/tasks/unit-windows/run.ps1
+++ b/tasks/unit-windows/run.ps1
@@ -1,0 +1,15 @@
+. .\ci\tasks\scripts\go-build.ps1
+
+cd .\concourse
+
+go mod download
+
+$GinkgoVersion = go list -f '{{.Version}}' -m github.com/onsi/ginkgo/v2
+if ($LASTEXITCODE) { Throw "failed to determine Ginkgo version (exit code $LASTEXITCODE)" }
+
+go install "github.com/onsi/ginkgo/v2/ginkgo@$GinkgoVersion"
+if ($LASTEXITCODE) { Throw "Ginkgo installation failed (exit code $LASTEXITCODE)" }
+
+ginkgo -r -p ./go-archive
+
+Exit $LastExitCode

--- a/tasks/unit-windows/task.yml
+++ b/tasks/unit-windows/task.yml
@@ -1,0 +1,14 @@
+---
+platform: windows
+
+inputs:
+  - name: ci
+  - name: concourse
+
+caches:
+  - path: gopath/
+
+run:
+  path: powershell
+  args: 
+  - ci/tasks/unit-windows/run.ps1


### PR DESCRIPTION
extend testing on windows

- go-archive unit test must also run on windows platform

Sadly, I don't know how to test this properly from the Concourse CI side. 

Additionally, there is 1 test failing: https://github.com/concourse/concourse/blob/master/go-archive/tarfs/extract_test.go#L221 that requires a PR in Concourse repo (in preparation)

