### PR TITLE
fix: unit-baggageclaim-windows:task: use powershell to run scripts

### DIFF
--- a/tasks/unit-baggageclaim-windows/task.yml
+++ b/tasks/unit-baggageclaim-windows/task.yml
@@ -9,4 +9,6 @@ caches:
   - path: gopath/
 
 run:
-  path: ci/tasks/unit-baggageclaim-windows/run.ps1
+  path: powershell
+  args: 
+  - ci/tasks/unit-baggageclaim-windows/run.ps1


### PR DESCRIPTION
fix: unit-baggageclaim-windows:task: use powershell to run scripts

Fix for:

> start process: backend error: Exit status: 500, message: {"Type":"","Message":"create process: %1 is not a valid Win32 application.","Handle":"","ProcessID":"","Binary":""}

https://ci.concourse-ci.org/teams/main/pipelines/concourse/jobs/unit-baggageclaim/builds/375

As reported in: https://github.com/concourse/ci/pull/431#discussion_r3620303780